### PR TITLE
Safe frame

### DIFF
--- a/src/bit_machine/exec.rs
+++ b/src/bit_machine/exec.rs
@@ -414,7 +414,7 @@ impl BitMachine {
             let out_frame = self.write.last_mut().unwrap();
             out_frame.reset_cursor();
             Value::from_bits_and_type(
-                &mut out_frame.with_data(&self.data),
+                &mut out_frame.to_frame_data(&self.data),
                 &program.root_node().target_ty,
             )
             .expect("unwrapping output value")

--- a/src/bit_machine/frame.rs
+++ b/src/bit_machine/frame.rs
@@ -148,8 +148,9 @@ impl Frame {
         }
     }
 
-    /// Adds
-    pub fn with_data<'a>(&self, data: &'a [u8]) -> FrameData<'a> {
+    /// Extend the present frame with a read-only reference the the data
+    /// and return the resulting struct.
+    pub fn to_frame_data<'a>(&self, data: &'a [u8]) -> FrameData<'a> {
         FrameData::new(self, data)
     }
 
@@ -321,10 +322,10 @@ mod tests {
     }
 
     #[test]
-    fn test_with_data_iter() {
+    fn test_to_frame_data_iter() {
         let bytes = (0..100).collect::<Vec<u8>>();
         let frame = Frame::new(0, 100 * 8);
-        let bits = frame.with_data(&bytes).collect();
+        let bits = frame.to_frame_data(&bytes).collect();
         let computed_bytes = bitvec_to_bytevec(bits);
 
         assert_eq!(bytes, computed_bytes);

--- a/src/bit_machine/frame.rs
+++ b/src/bit_machine/frame.rs
@@ -15,227 +15,283 @@
 
 //! # Simplicity Frame
 //!
-//! Implementation of the Frame in Simplicity BitMachine.
+//! Implementation of Frames in the Simplicity BitMachine.
 //! A frame is a, possibly empty, cell array with a cursor referencing
 //! a cell in the array.
 
-use std::{fmt, ptr};
+use std::fmt;
+use std::mem::size_of;
+use std::ops::{Add, Shl};
 
-/// A frame used internally by the Bit Machine to keep track of
-/// where we are reading or writing to
+/// Context to access a sub-slice of [`super::exec::BitMachine`]'s data.
+/// Read and write operations require a reference to the data,
+/// as it is not contained in this struct.
+#[derive(Debug, Eq, PartialEq)]
 pub(crate) struct Frame {
-    /// Base pointer to the data
-    pub(in crate::bit_machine) data: *mut u8,
-    /// Current position of the cursor. For read frames this points to
-    /// the next bit which is to be read. For write frames, this corresponds
-    /// to the next bit where data would be written
-    pub(in crate::bit_machine) abs_pos: isize,
-    /// Start index in of this frame in data
-    pub(in crate::bit_machine) start: isize,
+    /// Current position of the cursor.
+    /// For read frames, this is the next bit which is to be read.
+    /// For write frames, this is the next bit which is to be (over)written.
+    pub(crate) cursor: usize,
+    /// Start index of this frame in the referenced data.
+    pub(crate) start: usize,
     /// The total length of this frame.
-    pub(in crate::bit_machine) len: isize,
+    pub(crate) len: usize,
 }
 
-impl fmt::Debug for Frame {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        unsafe {
-            for i in 0..self.len {
-                if i == self.abs_pos - self.start {
-                    f.write_str("^")?;
-                }
+impl Frame {
+    /// Create a new frame that starts at the given index and that is of given length.
+    pub(crate) fn new(start: usize, len: usize) -> Self {
+        Frame {
+            cursor: start,
+            start,
+            len,
+        }
+    }
 
-                let p = self.data.offset((self.start + i) / 8);
-                if *p & (1 << (7 - (self.start + i) % 8)) != 0 {
-                    f.write_str("1")?;
-                } else {
-                    f.write_str("0")?;
-                }
+    /// Reset the cursor to the start.
+    pub(crate) fn reset_cursor(&mut self) {
+        self.cursor = self.start;
+    }
+
+    /// Return the current bit.
+    pub(crate) fn peek_bit(&self, data: &[u8]) -> bool {
+        let (byte_index, bit_index) = get_indices(self.cursor);
+        data[byte_index] & (1 << (7 - bit_index)) != 0
+    }
+
+    /// Return the current bit and advance the cursor.
+    pub(crate) fn read_bit(&mut self, data: &[u8]) -> bool {
+        let (byte_index, bit_index) = get_indices(self.cursor);
+        let bit = data[byte_index] & (1 << (7 - bit_index)) != 0;
+        self.cursor += 1;
+        bit
+    }
+
+    /// Read a big-endian u8 value and advance the cursor.
+    pub(crate) fn read_u8(&mut self, data: &[u8]) -> u8 {
+        self.read_unsigned(data)
+    }
+
+    /// Read a big-endian u16 value and advance the cursor.
+    pub(crate) fn read_u16(&mut self, data: &[u8]) -> u16 {
+        self.read_unsigned(data)
+    }
+
+    /// Read a big-endian u32 value and advance the cursor.
+    pub(crate) fn read_u32(&mut self, data: &[u8]) -> u32 {
+        self.read_unsigned(data)
+    }
+
+    /// Read a big-endian u64 value and advance the cursor.
+    pub(crate) fn read_u64(&mut self, data: &[u8]) -> u64 {
+        self.read_unsigned(data)
+    }
+
+    /// Write the given value to the current bit and advance the cursor.
+    pub(crate) fn write_bit(&mut self, bit: bool, data: &mut [u8]) {
+        let (byte_index, bit_index) = get_indices(self.cursor);
+        let write_mask = 1 << (7 - bit_index);
+
+        if bit {
+            data[byte_index] |= write_mask;
+        } else {
+            data[byte_index] &= !write_mask;
+        }
+
+        self.cursor += 1;
+    }
+
+    /// Write a big-endian u8 value and advance the cursor.
+    pub(crate) fn write_u8(&mut self, value: u8, data: &mut [u8]) {
+        for idx in 0..8 {
+            self.write_bit(value & (1 << (7 - idx)) != 0, data);
+        }
+    }
+
+    /// Write a big-endian u8 value and advance the cursor.
+    pub(crate) fn write_u16(&mut self, value: u16, data: &mut [u8]) {
+        for idx in 0..16 {
+            self.write_bit(value & (1 << (15 - idx)) != 0, data);
+        }
+    }
+
+    /// Write a big-endian u8 value and advance the cursor.
+    pub(crate) fn write_u32(&mut self, value: u32, data: &mut [u8]) {
+        for idx in 0..32 {
+            self.write_bit(value & (1 << (31 - idx)) != 0, data);
+        }
+    }
+
+    /// Write a big-endian u8 value and advance the cursor.
+    pub(crate) fn write_u64(&mut self, value: u64, data: &mut [u8]) {
+        for idx in 0..64 {
+            self.write_bit(value & (1 << (63 - idx)) != 0, data);
+        }
+    }
+
+    /// Move the cursor forward by the given length.
+    pub(crate) fn move_cursor_forward(&mut self, len: usize) {
+        self.cursor += len;
+    }
+
+    /// Move the cursor backward by the given length.
+    pub(crate) fn move_cursor_backward(&mut self, len: usize) {
+        self.cursor -= len;
+    }
+
+    /// Copy a bit string of given length from another frame into the present one.
+    pub(crate) fn copy_from(&mut self, other: &Self, len: usize, data: &mut [u8]) {
+        for i in 0..len {
+            let (other_byte_index, other_bit_index) = get_indices(other.cursor + i);
+            let bit = data[other_byte_index] & (1 << (7 - other_bit_index)) != 0;
+            self.write_bit(bit, data);
+        }
+    }
+
+    /// Adds
+    pub fn with_data<'a>(&self, data: &'a [u8]) -> FrameData<'a> {
+        FrameData::new(self, data)
+    }
+
+    fn read_unsigned<T>(&mut self, data: &[u8]) -> T
+    where
+        T: From<u8> + Shl<usize, Output = T> + Add<Output = T>,
+    {
+        let (mut self_byte_index, self_bit_index) = get_indices(self.cursor);
+        let mut read_number;
+
+        let number_bits = size_of::<T>() * 8;
+        let number_leading_bits = 8 - self_bit_index;
+        let number_full_bytes = (number_bits - number_leading_bits) / 8;
+        let number_trailing_bits = number_bits - number_leading_bits - number_full_bytes * 8;
+
+        // Read leading bits
+        let read_mask = 0xff >> self_bit_index;
+        let masked_data = data[self_byte_index] & read_mask;
+        read_number = T::from(masked_data << self_bit_index);
+        self_byte_index += 1;
+
+        for _ in 0..number_full_bytes {
+            let current_number = T::from(data[self_byte_index]) << self_bit_index;
+            read_number = (read_number << 8) + current_number;
+            self_byte_index += 1;
+        }
+
+        if number_trailing_bits != 0 {
+            let read_mask = 0xff << (8 - number_trailing_bits);
+            let masked_data = data[self_byte_index] & read_mask;
+            read_number = read_number + T::from(masked_data >> (8 - number_trailing_bits));
+        }
+
+        self.cursor += number_bits;
+        read_number
+    }
+}
+
+/// View onto a sub-slice of the Bit Machine's data.
+/// In contrast to [`Frame`],
+/// this struct contains a read-only reference to the data
+/// and can print / iterate over it.
+#[derive(Eq, PartialEq)]
+pub(crate) struct FrameData<'a> {
+    data: &'a [u8],
+    start: usize,
+    cursor: usize,
+    end: usize,
+}
+
+impl<'a> FrameData<'a> {
+    fn new(frame: &Frame, data: &'a [u8]) -> Self {
+        FrameData {
+            data,
+            start: frame.start,
+            cursor: frame.cursor,
+            end: frame.start + frame.len,
+        }
+    }
+}
+
+impl<'a> fmt::Debug for FrameData<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("[")?;
+
+        for i in self.start..self.end {
+            if i == self.cursor {
+                f.write_str("^")?;
+            }
+
+            let (byte_index, bit_index) = get_indices(i);
+            let bit = self.data[byte_index] & (1 << (7 - bit_index)) != 0;
+
+            if bit {
+                f.write_str("1")?;
+            } else {
+                f.write_str("0")?;
             }
         }
+
+        if self.cursor == self.end {
+            f.write_str("^")?;
+        }
+
+        f.write_str("]")?;
         Ok(())
     }
 }
 
-impl Iterator for Frame {
+impl<'a> ExactSizeIterator for FrameData<'a> {
+    fn len(&self) -> usize {
+        self.end - self.start
+    }
+}
+
+impl<'a> Iterator for FrameData<'a> {
     type Item = bool;
-    fn next(&mut self) -> Option<bool> {
-        if self.abs_pos < self.start + self.len {
-            let bit = self.peek_bit();
-            self.abs_pos += 1;
-            Some(bit)
-        } else {
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.cursor >= self.end {
             None
-        }
-    }
-}
-
-macro_rules! READ_UNSIGNED {
-    ($fn_name: ident, $ret_ty: ty) => {
-        pub(crate) fn $fn_name(&mut self) -> $ret_ty {
-            unsafe {
-                let ret_size = std::mem::size_of::<$ret_ty>() as isize;
-                let init_pos = self.abs_pos;
-                // 1. read all bits till the end of the current byte.
-                // Reads between 1 bit and 8 bits inclusive.
-                let mut ret: $ret_ty = 0;
-                let mask = 0xFF >> (self.abs_pos % 8);
-                let mut p = self.data.offset(self.abs_pos / 8);
-                ret += (mask & *p as $ret_ty);
-                self.abs_pos += 8 - (self.abs_pos % 8);
-                p = p.add(1);
-
-                // 2. Read the next bytes that can be completely read
-                for _ in 0..(ret_size - (self.abs_pos - init_pos + 7) / 8) {
-                    ret = ret * (2 as $ret_ty).pow(8) + (*p as $ret_ty);
-                    self.abs_pos += 8;
-                    p = p.add(1);
-                    debug_assert!(self.abs_pos % 8 == 0);
-                }
-
-                //3. Read partially the last byte if required
-                let remaining_bits = ret_size * 8 - (self.abs_pos - init_pos);
-                if remaining_bits != 0 {
-                    let mask = 0xff;
-                    ret = ret * (2 as $ret_ty).pow(remaining_bits as u32)
-                        + ((mask & *p) >> (8 - remaining_bits)) as $ret_ty;
-                    self.abs_pos += remaining_bits;
-                }
-                ret
-            }
-        }
-    };
-}
-
-impl Frame {
-    pub(in crate::bit_machine) fn read_at_rel(&self, n: isize) -> bool {
-        unsafe {
-            let p = self.data.offset((self.abs_pos + n) / 8);
-            *p & (1 << (7 - (self.abs_pos + n) % 8)) != 0
-        }
-    }
-
-    pub(in crate::bit_machine) fn peek_bit(&self) -> bool {
-        unsafe {
-            let p = self.data.offset(self.abs_pos / 8);
-            *p & (1 << (7 - self.abs_pos % 8)) != 0
-        }
-    }
-
-    pub(crate) fn read_bit(&mut self) -> bool {
-        unsafe {
-            let p = self.data.offset(self.abs_pos / 8);
-            let ret = *p & (1 << (7 - self.abs_pos % 8)) != 0;
-            self.abs_pos += 1;
-            ret
-        }
-    }
-
-    READ_UNSIGNED!(read_u8, u8);
-    READ_UNSIGNED!(read_u16, u16);
-    READ_UNSIGNED!(read_u32, u32);
-    READ_UNSIGNED!(read_u64, u64);
-
-    /// Write a big-endian u64 value to the current write frame
-    pub(in crate::bit_machine) fn write_u64(&mut self, data: u64) {
-        for idx in 0..64 {
-            self.write_bit(data & (1 << (63 - idx)) != 0);
-        }
-    }
-
-    /// Write a big-endian u32 value to the current write frame
-    pub(in crate::bit_machine) fn write_u32(&mut self, data: u32) {
-        for idx in 0..32 {
-            self.write_bit(data & (1 << (31 - idx)) != 0);
-        }
-    }
-
-    /// Write a big-endian u16 value to the current write frame
-    pub(in crate::bit_machine) fn write_u16(&mut self, data: u16) {
-        for idx in 0..16 {
-            self.write_bit(data & (1 << (15 - idx)) != 0);
-        }
-    }
-
-    /// Write a big-endian u8 value to the current write frame
-    pub(in crate::bit_machine) fn write_u8(&mut self, data: u8) {
-        for idx in 0..8 {
-            self.write_bit(data & (1 << (7 - idx)) != 0);
-        }
-    }
-
-    pub(in crate::bit_machine) fn write_bit(&mut self, b: bool) {
-        let mask = 1 << (7 - self.abs_pos % 8);
-        unsafe {
-            let p = self.data.offset(self.abs_pos / 8);
-            if b {
-                *p |= mask;
-            } else {
-                *p &= !mask;
-            }
-        }
-        self.abs_pos += 1;
-    }
-
-    pub(in crate::bit_machine) fn fwd(&mut self, n: usize) {
-        self.abs_pos += n as isize;
-    }
-
-    pub(in crate::bit_machine) fn back(&mut self, n: usize) {
-        self.abs_pos -= n as isize;
-    }
-
-    pub(in crate::bit_machine) fn copy_from(&mut self, other: &Frame, n: usize) {
-        if self.abs_pos % 8 == 0 && other.abs_pos % 8 == 0 {
-            unsafe {
-                ptr::copy_nonoverlapping(
-                    other.data.offset(other.abs_pos / 8),
-                    self.data.offset(self.abs_pos / 8),
-                    (n + 7) / 8,
-                );
-                self.abs_pos += n as isize;
-            }
         } else {
-            for i in 0..n as isize {
-                let bit = unsafe {
-                    let p = other.data.offset((other.abs_pos + i) / 8);
-                    *p & (1 << (7 - (other.abs_pos + i) % 8)) != 0
-                };
-                self.write_bit(bit);
-            }
+            let (byte_index, bit_index) = get_indices(self.cursor);
+            let next_bit = self.data[byte_index] & (1 << (7 - bit_index)) != 0;
+            self.cursor += 1;
+            Some(next_bit)
         }
     }
+}
+
+fn get_indices(cursor: usize) -> (usize, usize) {
+    let byte_index = cursor / 8;
+    let bit_index = cursor % 8;
+
+    (byte_index, bit_index)
 }
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
+    use crate::core::bitvec_to_bytevec;
 
     #[test]
-    fn read_u8() {
-        let mut v = (0..100).collect::<Vec<u8>>();
-        let p = v.as_mut_ptr();
-        let mut f = Frame {
-            data: p,
-            abs_pos: 0,
-            len: 8 * 100,
-            start: 0,
-        };
-        assert_eq!(f.read_u8(), 0);
-        assert_eq!(f.read_u8(), 1);
-        assert_eq!(f.read_u8(), 2);
-        assert_eq!(f.read_u16(), 3 * 256 + 4);
-        assert_eq!(f.read_u16(), 5 * 256 + 6);
+    fn read_unsigned() {
+        let bytes = (0..100).collect::<Vec<u8>>();
+        let mut frame = Frame::new(0, 100 * 8);
+
+        assert_eq!(frame.read_u8(&bytes), 0);
+        assert_eq!(frame.read_u8(&bytes), 1);
+        assert_eq!(frame.read_u8(&bytes), 2);
+        assert_eq!(frame.read_u16(&bytes), 3 * 256 + 4);
+        assert_eq!(frame.read_u16(&bytes), 5 * 256 + 6);
         assert_eq!(
-            f.read_u32(),
+            frame.read_u32(&bytes),
             7 * 2u32.pow(24) + 8 * 2u32.pow(16) + 9 * 2u32.pow(8) + 10
         );
         assert_eq!(
-            f.read_u32(),
+            frame.read_u32(&bytes),
             11 * 2u32.pow(24) + 12 * 2u32.pow(16) + 13 * 2u32.pow(8) + 14
         );
         assert_eq!(
-            f.read_u64(),
+            frame.read_u64(&bytes),
             15 * 2u64.pow(8 * 7)
                 + 16 * 2u64.pow(8 * 6)
                 + 17 * 2u64.pow(8 * 5)
@@ -246,21 +302,31 @@ mod tests {
                 + 22
         );
 
-        // assert_eq!(f.read_u8(), 23);
+        // assert_eq!(f.read_u8(&vector), 23);
         // 23 = 0001 0111
         // our iterator reads from behind, so it should read
         // 0 -> 0 -> 0 -> 1
-        assert_eq!(f.read_bit(), false);
-        assert_eq!(f.read_bit(), false);
-        assert_eq!(f.read_bit(), false);
-        assert_eq!(f.read_bit(), true);
+        assert_eq!(frame.read_bit(&bytes), false);
+        assert_eq!(frame.read_bit(&bytes), false);
+        assert_eq!(frame.read_bit(&bytes), false);
+        assert_eq!(frame.read_bit(&bytes), true);
 
         // (0111 | 0001) 1000
         // 16*7 + 1 = 113
-        assert_eq!(f.read_u8(), 113);
-        assert_eq!(f.read_bit(), true);
-        assert_eq!(f.read_u8(), 3);
-        assert_eq!(f.read_u16(), 9027);
-        assert_eq!(f.read_u32(), 1669571523);
+        assert_eq!(frame.read_u8(&bytes), 113);
+        assert_eq!(frame.read_bit(&bytes), true);
+        assert_eq!(frame.read_u8(&bytes), 3);
+        assert_eq!(frame.read_u16(&bytes), 9027);
+        assert_eq!(frame.read_u32(&bytes), 1669571523);
+    }
+
+    #[test]
+    fn test_with_data_iter() {
+        let bytes = (0..100).collect::<Vec<u8>>();
+        let frame = Frame::new(0, 100 * 8);
+        let bits = frame.with_data(&bytes).collect();
+        let computed_bytes = bitvec_to_bytevec(bits);
+
+        assert_eq!(bytes, computed_bytes);
     }
 }

--- a/src/core/term.rs
+++ b/src/core/term.rs
@@ -294,8 +294,8 @@ impl Value {
     pub fn u4(n: u8) -> Value {
         let w0 = (n & 12) / 4;
         let w1 = n & 3;
-        if n > 7 {
-            panic!("{} out of range for Value::u2", n);
+        if n > 15 {
+            panic!("{} out of range for Value::u4", n);
         }
         Value::Prod(Box::new(Value::u2(w0)), Box::new(Value::u2(w1)))
     }


### PR DESCRIPTION
Removes unsafe code from `frame.rs` (crate is now completely safe).
Bits are copied one by one from one frame to another. More efficient methods are possible, but require longer code _(let's discuss readability vs efficiency)_.