### PR TITLE
Iterators

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -27,5 +27,13 @@ name = "rtt_program"
 path = "fuzz_targets/rtt_program.rs"
 
 [[bin]]
+name = "rtt_witness"
+path = "fuzz_targets/rtt_witness.rs"
+
+[[bin]]
+name = "rtt_program_witness"
+path = "fuzz_targets/rtt_program_witness.rs"
+
+[[bin]]
 name = "rtt_dag"
 path = "fuzz_targets/rtt_dag.rs"

--- a/fuzz/fuzz_targets/rtt_dag.rs
+++ b/fuzz/fuzz_targets/rtt_dag.rs
@@ -15,14 +15,15 @@
 extern crate simplicity;
 
 use simplicity::bititer::BitIter;
-use simplicity::core::TermDag;
-use simplicity::decode;
+use simplicity::core::{TermDag, UntypedProgram};
 use simplicity::jet::application::Core;
 
 fn do_test(data: &[u8]) {
     let mut iter = BitIter::new(data.iter().cloned());
 
-    if let Ok(program) = decode::decode_program_no_witness::<_, Core>(&mut iter) {
+    if let Ok(program) = UntypedProgram::<_, Core>::decode(&mut iter) {
+        // println!("{:?}", program);
+
         let dag = TermDag::from_linear(&program);
         let program_from_dag = dag.to_linear();
         assert_eq!(program, program_from_dag);

--- a/fuzz/fuzz_targets/rtt_natural.rs
+++ b/fuzz/fuzz_targets/rtt_natural.rs
@@ -22,6 +22,7 @@ fn do_test(data: &[u8]) {
     let mut iter = BitIter::new(data.iter().cloned());
 
     if let Ok(natural) = decode::decode_natural(&mut iter, None) {
+        // println!("{:?}", natural);
         let bit_len = iter.n_total_read();
 
         let mut sink = Vec::<u8>::new();

--- a/fuzz/fuzz_targets/rtt_program.rs
+++ b/fuzz/fuzz_targets/rtt_program.rs
@@ -16,7 +16,6 @@ extern crate simplicity;
 
 use simplicity::bititer::BitIter;
 use simplicity::core::UntypedProgram;
-use simplicity::encode;
 use simplicity::encode::BitWriter;
 use simplicity::jet::application::Core;
 
@@ -29,7 +28,7 @@ fn do_test(data: &[u8]) {
 
         let mut sink = Vec::<u8>::new();
         let mut w = BitWriter::from(&mut sink);
-        encode::encode_program_no_witness(program.iter(), &mut w).expect("encoding to vector");
+        program.encode(&mut w).expect("encoding to vector");
         w.flush_all().expect("flushing");
         assert_eq!(w.n_total_written(), bit_len);
 

--- a/fuzz/fuzz_targets/rtt_program.rs
+++ b/fuzz/fuzz_targets/rtt_program.rs
@@ -15,21 +15,22 @@
 extern crate simplicity;
 
 use simplicity::bititer::BitIter;
+use simplicity::core::UntypedProgram;
+use simplicity::encode;
 use simplicity::encode::BitWriter;
 use simplicity::jet::application::Core;
-use simplicity::{decode, encode};
 
 fn do_test(data: &[u8]) {
     let mut iter = BitIter::new(data.iter().cloned());
 
-    if let Ok(program) = decode::decode_program_no_witness::<_, Core>(&mut iter) {
+    if let Ok(program) = UntypedProgram::<_, Core>::decode(&mut iter) {
+        // println!("{:?}", program);
         let bit_len = iter.n_total_read();
 
         let mut sink = Vec::<u8>::new();
         let mut w = BitWriter::from(&mut sink);
         encode::encode_program_no_witness(program.iter(), &mut w).expect("encoding to vector");
         w.flush_all().expect("flushing");
-        // println!("{:?}", program);
         assert_eq!(w.n_total_written(), bit_len);
 
         // decode_program_no_witness() may stop reading `data` mid-byte:

--- a/fuzz/fuzz_targets/rtt_program.rs
+++ b/fuzz/fuzz_targets/rtt_program.rs
@@ -27,7 +27,7 @@ fn do_test(data: &[u8]) {
 
         let mut sink = Vec::<u8>::new();
         let mut w = BitWriter::from(&mut sink);
-        encode::encode_program_no_witness(&program, &mut w).expect("encoding to vector");
+        encode::encode_program_no_witness(program.iter(), &mut w).expect("encoding to vector");
         w.flush_all().expect("flushing");
         // println!("{:?}", program);
         assert_eq!(w.n_total_written(), bit_len);

--- a/fuzz/fuzz_targets/rtt_program_witness.rs
+++ b/fuzz/fuzz_targets/rtt_program_witness.rs
@@ -1,0 +1,66 @@
+// Rust Simplicity Library
+// Written in 2022 by
+//   Christian Lewe <clewe@blockstream.com>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+extern crate simplicity;
+
+use simplicity::bititer::BitIter;
+use simplicity::core::{TypedProgram, Value};
+use simplicity::encode::BitWriter;
+use simplicity::jet::application::Core;
+
+fn do_test(data: &[u8]) {
+    let mut iter = BitIter::new(data.iter().cloned());
+
+    if let Ok(program) = TypedProgram::<Value, Core>::decode(&mut iter) {
+        // println!("{:?}", program);
+        let bit_len = iter.n_total_read();
+
+        let mut sink = Vec::<u8>::new();
+        let mut w = BitWriter::from(&mut sink);
+        program.encode(&mut w).expect("encoding to vector");
+        w.flush_all().expect("flushing");
+        assert_eq!(w.n_total_written(), bit_len);
+
+        // TypedProgram::<Value, Core>::decode() may stop reading `data` mid-byte:
+        // copy trailing bits from `data` to `sink`
+        if bit_len % 8 != 0 {
+            let mask = !(1u8 << (8 - (bit_len % 8)));
+            let idx = sink.len() - 1;
+            sink[idx] |= data[idx] & mask;
+        }
+        assert_eq!(sink, &data[0..sink.len()]);
+    }
+}
+
+#[cfg(feature = "afl")]
+#[macro_use]
+extern crate afl;
+#[cfg(feature = "afl")]
+fn main() {
+    fuzz!(|data| {
+        do_test(&data);
+    });
+}
+
+#[cfg(feature = "honggfuzz")]
+#[macro_use]
+extern crate honggfuzz;
+#[cfg(feature = "honggfuzz")]
+fn main() {
+    loop {
+        fuzz!(|data| {
+            do_test(data);
+        });
+    }
+}

--- a/fuzz/fuzz_targets/rtt_witness.rs
+++ b/fuzz/fuzz_targets/rtt_witness.rs
@@ -1,0 +1,71 @@
+// Rust Simplicity Library
+// Written in 2022 by
+//   Christian Lewe <clewe@blockstream.com>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+extern crate simplicity;
+
+use simplicity::bititer::BitIter;
+use simplicity::core::TermDag;
+use simplicity::encode::BitWriter;
+use simplicity::jet;
+use simplicity::{decode, encode};
+
+fn do_test(data: &[u8]) {
+    let mut iter = BitIter::new(data.iter().cloned());
+    let typed = TermDag::comp(TermDag::witness(()), TermDag::jet(&jet::core::ADD32))
+        .to_linear()
+        .type_check()
+        .expect("type check");
+
+    if let Ok(witness) = decode::decode_witness(&typed, &mut iter) {
+        // println!("{:?}", witness);
+        let bit_len = iter.n_total_read();
+
+        let mut sink = Vec::<u8>::new();
+        let mut w = BitWriter::from(&mut sink);
+        encode::encode_witness(witness.iter(), &mut w).expect("encoding to vector");
+        w.flush_all().expect("flushing");
+        assert_eq!(w.n_total_written(), bit_len);
+
+        // decode_witness() may stop reading `data` mid-byte:
+        // copy trailing bits from `data` to `sink`
+        if bit_len % 8 != 0 {
+            let mask = !(1u8 << (8 - (bit_len % 8)));
+            let idx = sink.len() - 1;
+            sink[idx] |= data[idx] & mask;
+        }
+        assert_eq!(sink, &data[0..sink.len()]);
+    }
+}
+
+#[cfg(feature = "afl")]
+#[macro_use]
+extern crate afl;
+#[cfg(feature = "afl")]
+fn main() {
+    fuzz!(|data| {
+        do_test(&data);
+    });
+}
+
+#[cfg(feature = "honggfuzz")]
+#[macro_use]
+extern crate honggfuzz;
+#[cfg(feature = "honggfuzz")]
+fn main() {
+    loop {
+        fuzz!(|data| {
+            do_test(data);
+        });
+    }
+}

--- a/src/core/iter.rs
+++ b/src/core/iter.rs
@@ -40,6 +40,7 @@ pub trait DagIterable: Sized {
 /// Iterates over a DAG in _post order_.
 /// That means, left children appear before right ones, and children appear before their parent.
 /// Shared nodes appear only once at their leftmost position.
+#[derive(Clone, Debug)]
 pub struct PostOrderIter<'a, D: DagIterable> {
     dag: &'a D,
     stack: Vec<D::Node>,

--- a/src/core/iter.rs
+++ b/src/core/iter.rs
@@ -14,6 +14,8 @@
 
 //! Iterators over DAGs
 
+use crate::core::Term;
+use crate::jet::Application;
 use std::collections::HashSet;
 use std::hash::Hash;
 
@@ -93,4 +95,21 @@ impl<'a, D: DagIterable> Iterator for PostOrderIter<'a, D> {
             }
         }
     }
+}
+
+/// Convert the given iterator over [`Term`]s into an iterator over the contained `Witness` values.
+pub fn into_witness<'a, Witness, App: Application, I>(
+    iter: I,
+) -> impl Iterator<Item = &'a Witness> + Clone
+where
+    Witness: 'a,
+    I: Iterator<Item = &'a Term<Witness, App>> + Clone,
+{
+    iter.filter_map(|term| {
+        if let Term::Witness(value) = term {
+            Some(value)
+        } else {
+            None
+        }
+    })
 }

--- a/src/core/program.rs
+++ b/src/core/program.rs
@@ -85,7 +85,7 @@ pub struct Program<App: Application> {
 
 impl<App: Application> Program<App> {
     /// Return an iterator over the nodes of the program.
-    pub fn iter(&self) -> impl Iterator<Item = &ProgramNode<App>> {
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = &ProgramNode<App>> + Clone {
         self.nodes.iter()
     }
 

--- a/src/core/program.rs
+++ b/src/core/program.rs
@@ -20,15 +20,16 @@
 //!
 
 use std::collections::{HashMap, HashSet};
-use std::fmt;
+use std::{fmt, io};
 
 use crate::bititer::BitIter;
 use crate::core::types::FinalType;
-use crate::core::{LinearProgram, Term, TypedNode, TypedProgram, Value};
+use crate::core::{iter, LinearProgram, Term, TypedNode, TypedProgram, Value};
+use crate::encode::BitWriter;
 use crate::jet::Application;
 use crate::merkle::cmr::Cmr;
 use crate::merkle::imr::Imr;
-use crate::Error;
+use crate::{encode, Error};
 
 /// Simplicity node with full metadata for the time of redemption.
 /// This type of node is executed on the Bit Machine.
@@ -89,6 +90,11 @@ impl<App: Application> Program<App> {
         self.nodes.iter()
     }
 
+    /// Return an iterator over the terms of the program.
+    pub fn iter_terms(&self) -> impl ExactSizeIterator<Item = &Term<Value, App>> + Clone {
+        self.nodes.iter().map(|x| &x.typed.term)
+    }
+
     /// Decode a finalized program from bits.
     pub fn decode<I: Iterator<Item = u8>>(iter: &mut BitIter<I>) -> Result<Self, Error> {
         let program = Program::decode_insane(iter)?;
@@ -107,6 +113,15 @@ impl<App: Application> Program<App> {
         let typed_program = TypedProgram::<Value, App>::decode(iter)?;
         let finalized_program = typed_program.finalize_insane();
         Ok(finalized_program)
+    }
+
+    /// Encode the program into bits.
+    ///
+    /// Returns the number of written bits.
+    pub fn encode<W: io::Write>(&self, w: &mut BitWriter<W>) -> io::Result<usize> {
+        let program_bits = encode::encode_program_no_witness(self.iter_terms(), w)?;
+        let witness_bits = encode::encode_witness(iter::into_witness(self.iter_terms()), w)?;
+        Ok(program_bits + witness_bits)
     }
 
     /// Check if the program has maximal sharing.

--- a/src/core/term.rs
+++ b/src/core/term.rs
@@ -201,7 +201,7 @@ impl<App: Application> UntypedProgram<(), App> {
 
 impl<Witness, App: Application> UntypedProgram<Witness, App> {
     /// Return an iterator over the nodes of the program.
-    pub fn iter(&self) -> impl Iterator<Item = &Term<Witness, App>> {
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = &Term<Witness, App>> + Clone {
         self.0.iter()
     }
 

--- a/src/core/typed.rs
+++ b/src/core/typed.rs
@@ -78,7 +78,7 @@ impl<App: Application> TypedProgram<(), App> {
 
 impl<Witness, App: Application> TypedProgram<Witness, App> {
     /// Return an iterator over the nodes of the program.
-    pub fn iter(&self) -> impl Iterator<Item = &TypedNode<Witness, App>> {
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = &TypedNode<Witness, App>> + Clone {
         self.0.iter()
     }
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -68,9 +68,9 @@ pub fn decode_witness<Wit, App: Application, I: Iterator<Item = u8>>(
         }
     }
 
-    if iter.n_total_read() - n_start > bit_len {
+    if iter.n_total_read() - n_start != bit_len {
         Err(Error::ParseError(
-            "Witness bit string is longer than defined in its preamble!",
+            "Witness bit string has different length than defined in its preamble",
         ))
     } else {
         Ok(witness)

--- a/src/jet/mod.rs
+++ b/src/jet/mod.rs
@@ -44,7 +44,7 @@ use std::io::Write;
 
 /// Applications extend Simplicity by providing [`JetNode`]s
 /// with custom (de)serialization and execution.
-pub trait Application: Sized + 'static {
+pub trait Application: Clone + 'static {
     /// Environment for jets to read from
     type Environment;
     /// Custom application errors


### PR DESCRIPTION
This PR makes the encoding use iterators over terms and values (instead of slices) for more flexibility. Encoding methods were added for all program types, which use the type system to infer whether there is a witness. Finally, fuzz tests were added to check roundtrips of (program +) witness de/encoding, and bugs were fixed.