### PR TITLE
Types

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -28,7 +28,7 @@ pub(crate) fn compute_extra_cells_bound<App: Application>(
             program[node.index - i].extra_cells_bound
         }
         Term::Comp(i, j) => {
-            program[node.index - i].target_ty().bit_width()
+            program[node.index - i].target_ty().bit_width
                 + cmp::max(
                     program[node.index - i].extra_cells_bound,
                     program[node.index - j].extra_cells_bound,
@@ -41,8 +41,8 @@ pub(crate) fn compute_extra_cells_bound<App: Application>(
             )
         }
         Term::Disconnect(i, j) => {
-            program[node.index - i].source_ty().bit_width()
-                + program[node.index - i].target_ty().bit_width()
+            program[node.index - i].source_ty().bit_width
+                + program[node.index - i].target_ty().bit_width
                 + cmp::max(
                     program[node.index - i].extra_cells_bound,
                     program[node.index - j].extra_cells_bound,

--- a/src/bit_machine/exec.rs
+++ b/src/bit_machine/exec.rs
@@ -47,7 +47,7 @@ impl BitMachine {
     /// the given program
     pub fn for_program<App: Application>(program: &Program<App>) -> BitMachine {
         let prog = program.root();
-        let io_width = prog.source_ty().bit_width() + prog.target_ty().bit_width();
+        let io_width = prog.source_ty().bit_width + prog.target_ty().bit_width;
         BitMachine {
             data: vec![0; (io_width + prog.extra_cells_bound + 7) / 8],
             next_frame_start: 0,
@@ -286,14 +286,14 @@ impl BitMachine {
         let mut call_stack = vec![];
         let mut iters = 0u64;
 
-        let input_width = ip.source_ty.bit_width();
+        let input_width = ip.source_ty.bit_width;
         if input_width > 0 && self.read.is_empty() {
             panic!(
                 "Pleas call `Program::input` to add an input value for this program {}",
                 ip
             );
         }
-        let output_width = ip.target_ty.bit_width();
+        let output_width = ip.target_ty.bit_width;
         if output_width > 0 {
             self.new_frame(output_width);
         }
@@ -306,12 +306,12 @@ impl BitMachine {
 
             match ip.term {
                 Term::Unit => {}
-                Term::Iden => self.copy(ip.source_ty.bit_width()),
+                Term::Iden => self.copy(ip.source_ty.bit_width),
                 Term::InjL(t) => {
                     self.write_bit(false);
                     if let FinalTypeInner::Sum(ref a, _) = ip.target_ty.ty {
-                        let aw = a.bit_width();
-                        self.skip(ip.target_ty.bit_width() - aw - 1);
+                        let aw = a.bit_width;
+                        self.skip(ip.target_ty.bit_width - aw - 1);
                         call_stack.push(CallStack::Goto(ip.index - t));
                     } else {
                         panic!("type error")
@@ -320,8 +320,8 @@ impl BitMachine {
                 Term::InjR(t) => {
                     self.write_bit(true);
                     if let FinalTypeInner::Sum(_, ref b) = ip.target_ty.ty {
-                        let bw = b.bit_width();
-                        self.skip(ip.target_ty.bit_width() - bw - 1);
+                        let bw = b.bit_width;
+                        self.skip(ip.target_ty.bit_width - bw - 1);
                         call_stack.push(CallStack::Goto(ip.index - t));
                     } else {
                         panic!("type error")
@@ -332,7 +332,7 @@ impl BitMachine {
                     call_stack.push(CallStack::Goto(ip.index - s));
                 }
                 Term::Comp(s, t) => {
-                    let size = program.nodes[ip.index - s].target_ty().bit_width();
+                    let size = program.nodes[ip.index - s].target_ty().bit_width;
                     self.new_frame(size);
 
                     call_stack.push(CallStack::DropFrame);
@@ -342,14 +342,14 @@ impl BitMachine {
                 }
                 Term::Disconnect(s, t) => {
                     // Write `t`'s CMR followed by `s` input to a new read frame
-                    let size = program.nodes[ip.index - s].source_ty().bit_width();
+                    let size = program.nodes[ip.index - s].source_ty().bit_width;
                     assert!(size >= 256);
                     self.new_frame(size);
                     self.write_bytes(program.nodes[ip.index - t].cmr().as_ref());
                     self.copy(size - 256);
                     self.move_frame();
 
-                    let s_target_size = program.nodes[ip.index - s].target_ty().bit_width();
+                    let s_target_size = program.nodes[ip.index - s].target_ty().bit_width;
                     self.new_frame(s_target_size);
                     // Then recurse. Remembering that call stack pushes are executed
                     // in reverse order:
@@ -357,8 +357,7 @@ impl BitMachine {
                     // 3. Delete the two frames we created, which have both moved to the read stack
                     call_stack.push(CallStack::DropFrame);
                     call_stack.push(CallStack::DropFrame);
-                    let b_size =
-                        s_target_size - program.nodes[ip.index - t].source_ty().bit_width();
+                    let b_size = s_target_size - program.nodes[ip.index - t].source_ty().bit_width;
                     // Back not required since we are dropping the frame anyways
                     // call_stack.push(CallStack::Back(b_size));
                     // 2. Copy the first half of `s`s output directly then execute `t` on the second half
@@ -371,7 +370,7 @@ impl BitMachine {
                 Term::Take(t) => call_stack.push(CallStack::Goto(ip.index - t)),
                 Term::Drop(t) => {
                     if let FinalTypeInner::Product(ref a, _) = ip.source_ty.ty {
-                        let aw = a.bit_width();
+                        let aw = a.bit_width;
                         self.fwd(aw);
                         call_stack.push(CallStack::Back(aw));
                         call_stack.push(CallStack::Goto(ip.index - t));
@@ -385,8 +384,8 @@ impl BitMachine {
                     let bw;
                     if let FinalTypeInner::Product(ref a, _) = ip.source_ty.ty {
                         if let FinalTypeInner::Sum(ref a, ref b) = a.ty {
-                            aw = a.bit_width();
-                            bw = b.bit_width();
+                            aw = a.bit_width;
+                            bw = b.bit_width;
                         } else {
                             panic!("type error");
                         }

--- a/src/bit_machine/exec.rs
+++ b/src/bit_machine/exec.rs
@@ -22,7 +22,7 @@ use std::cmp;
 use std::error;
 use std::fmt;
 
-use crate::core::types::FinalTypeInner;
+use crate::core::types::TypeInner;
 use crate::core::{LinearProgram, Program, Term, Value};
 use crate::decode;
 use crate::jet::{AppError, Application};
@@ -309,7 +309,7 @@ impl BitMachine {
                 Term::Iden => self.copy(ip.source_ty.bit_width),
                 Term::InjL(t) => {
                     self.write_bit(false);
-                    if let FinalTypeInner::Sum(ref a, _) = ip.target_ty.ty {
+                    if let TypeInner::Sum(ref a, _) = ip.target_ty.ty {
                         let aw = a.bit_width;
                         self.skip(ip.target_ty.bit_width - aw - 1);
                         call_stack.push(CallStack::Goto(ip.index - t));
@@ -319,7 +319,7 @@ impl BitMachine {
                 }
                 Term::InjR(t) => {
                     self.write_bit(true);
-                    if let FinalTypeInner::Sum(_, ref b) = ip.target_ty.ty {
+                    if let TypeInner::Sum(_, ref b) = ip.target_ty.ty {
                         let bw = b.bit_width;
                         self.skip(ip.target_ty.bit_width - bw - 1);
                         call_stack.push(CallStack::Goto(ip.index - t));
@@ -369,7 +369,7 @@ impl BitMachine {
                 }
                 Term::Take(t) => call_stack.push(CallStack::Goto(ip.index - t)),
                 Term::Drop(t) => {
-                    if let FinalTypeInner::Product(ref a, _) = ip.source_ty.ty {
+                    if let TypeInner::Product(ref a, _) = ip.source_ty.ty {
                         let aw = a.bit_width;
                         self.fwd(aw);
                         call_stack.push(CallStack::Back(aw));
@@ -382,8 +382,8 @@ impl BitMachine {
                     let sw = self.read[self.read.len() - 1].peek_bit(&self.data);
                     let aw;
                     let bw;
-                    if let FinalTypeInner::Product(ref a, _) = ip.source_ty.ty {
-                        if let FinalTypeInner::Sum(ref a, ref b) = a.ty {
+                    if let TypeInner::Product(ref a, _) = ip.source_ty.ty {
+                        if let TypeInner::Sum(ref a, ref b) = a.ty {
                             aw = a.bit_width;
                             bw = b.bit_width;
                         } else {

--- a/src/core/program.rs
+++ b/src/core/program.rs
@@ -23,7 +23,7 @@ use std::collections::{HashMap, HashSet};
 use std::{fmt, io};
 
 use crate::bititer::BitIter;
-use crate::core::types::FinalType;
+use crate::core::types::Type;
 use crate::core::{iter, LinearProgram, Term, TypedNode, TypedProgram, Value};
 use crate::encode::BitWriter;
 use crate::jet::Application;
@@ -58,12 +58,12 @@ impl<App: Application> ProgramNode<App> {
     }
 
     /// Return the source type of the node.
-    pub fn source_ty(&self) -> &FinalType {
+    pub fn source_ty(&self) -> &Type {
         &self.typed.source_ty
     }
 
     /// Return the target type of the node.
-    pub fn target_ty(&self) -> &FinalType {
+    pub fn target_ty(&self) -> &Type {
         &self.typed.target_ty
     }
 

--- a/src/core/term.rs
+++ b/src/core/term.rs
@@ -26,12 +26,11 @@
 use crate::bititer::BitIter;
 use crate::core::iter::DagIterable;
 use crate::core::typed::TypedProgram;
-use crate::core::{iter, LinearProgram};
-use crate::core::{types, Value};
+use crate::core::{iter, LinearProgram, Value};
 use crate::encode::BitWriter;
 use crate::jet::{Application, JetNode};
 use crate::merkle::cmr::Cmr;
-use crate::{decode, encode, Error};
+use crate::{decode, encode, inference, Error};
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::io;
@@ -246,7 +245,7 @@ impl<Witness, App: Application> UntypedProgram<Witness, App> {
 
     /// Type-check the program and add metadata for the time of commitment.
     pub fn type_check(self) -> Result<TypedProgram<Witness, App>, Error> {
-        types::type_check(self)
+        inference::type_check(self)
     }
 }
 

--- a/src/core/typed.rs
+++ b/src/core/typed.rs
@@ -14,12 +14,12 @@
 
 use crate::bititer::BitIter;
 use crate::core::types::FinalType;
-use crate::core::{iter, types, LinearProgram, Program, ProgramNode, Term, UntypedProgram, Value};
+use crate::core::{iter, LinearProgram, Program, ProgramNode, Term, UntypedProgram, Value};
 use crate::encode::BitWriter;
 use crate::jet::Application;
 use crate::merkle::cmr::Cmr;
 use crate::merkle::imr;
-use crate::{analysis, decode, encode, Error};
+use crate::{analysis, decode, encode, inference, Error};
 use std::sync::Arc;
 use std::{fmt, io};
 
@@ -73,7 +73,7 @@ impl<App: Application> TypedProgram<(), App> {
     /// Decode a typed program from bits.
     pub fn decode<I: Iterator<Item = u8>>(iter: &mut BitIter<I>) -> Result<Self, Error> {
         let program = UntypedProgram::<(), App>::decode(iter)?;
-        types::type_check(program)
+        inference::type_check(program)
     }
 
     /// Encode the program into bits.

--- a/src/core/typed.rs
+++ b/src/core/typed.rs
@@ -13,7 +13,7 @@
 //
 
 use crate::bititer::BitIter;
-use crate::core::types::FinalType;
+use crate::core::types::Type;
 use crate::core::{iter, LinearProgram, Program, ProgramNode, Term, UntypedProgram, Value};
 use crate::encode::BitWriter;
 use crate::jet::Application;
@@ -29,9 +29,9 @@ pub struct TypedNode<Witness, App: Application> {
     /// Underlying term
     pub term: Term<Witness, App>,
     /// Source type of the node
-    pub source_ty: Arc<FinalType>,
+    pub source_ty: Arc<Type>,
     /// Target type of the node
-    pub target_ty: Arc<FinalType>,
+    pub target_ty: Arc<Type>,
     /// Index of the node inside the surrounding program
     pub index: usize,
     /// Commitment Merkle root of the node
@@ -127,7 +127,7 @@ impl<Witness, App: Application> TypedProgram<Witness, App> {
     }
 
     /// Return a vector of the types of values that make up a valid witness for the program.
-    pub fn get_witness_types(&self) -> Vec<&FinalType> {
+    pub fn get_witness_types(&self) -> Vec<&Type> {
         let mut witness_types = Vec::new();
 
         for node in &self.0 {

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -1,16 +1,6 @@
-//FIXME: Remove this later
-#![allow(dead_code)]
-
-use std::{cell::RefCell, cmp, fmt, mem, rc::Rc, sync::Arc};
-
-use crate::core::{Term, TypedNode, TypedProgram};
-use crate::jet::Application;
-use crate::merkle::cmr;
 use crate::merkle::common::{MerkleRoot, TypeMerkleRoot};
 use crate::merkle::tmr::Tmr;
-use crate::Error;
-
-use super::term::UntypedProgram;
+use std::{cell::RefCell, cmp, fmt, rc::Rc, sync::Arc};
 
 #[derive(Clone, Debug)]
 pub(crate) enum Type {
@@ -43,7 +33,7 @@ pub struct FinalType {
 }
 
 impl FinalType {
-    fn unit() -> Self {
+    pub fn unit() -> Self {
         let ty = FinalTypeInner::Unit;
 
         Self {
@@ -54,7 +44,7 @@ impl FinalType {
         }
     }
 
-    fn sum(a: Arc<Self>, b: Arc<Self>) -> Self {
+    pub fn sum(a: Arc<Self>, b: Arc<Self>) -> Self {
         let ty = FinalTypeInner::Sum(a.clone(), b.clone());
 
         Self {
@@ -69,7 +59,7 @@ impl FinalType {
         }
     }
 
-    fn prod(a: Arc<Self>, b: Arc<Self>) -> Self {
+    pub fn prod(a: Arc<Self>, b: Arc<Self>) -> Self {
         let ty = FinalTypeInner::Product(a.clone(), b.clone());
 
         Self {
@@ -95,24 +85,6 @@ impl FinalType {
     }
 }
 
-pub(crate) fn pow2_types() -> [Arc<FinalType>; 11] {
-    let word0 = Arc::new(FinalType::unit());
-    let word1 = Arc::new(FinalType::sum(Arc::clone(&word0), Arc::clone(&word0)));
-    let word2 = Arc::new(FinalType::prod(Arc::clone(&word1), Arc::clone(&word1)));
-    let word4 = Arc::new(FinalType::prod(Arc::clone(&word2), Arc::clone(&word2)));
-    let word8 = Arc::new(FinalType::prod(Arc::clone(&word4), Arc::clone(&word4)));
-    let word16 = Arc::new(FinalType::prod(Arc::clone(&word8), Arc::clone(&word8)));
-    let word32 = Arc::new(FinalType::prod(Arc::clone(&word16), Arc::clone(&word16)));
-    let word64 = Arc::new(FinalType::prod(Arc::clone(&word32), Arc::clone(&word32)));
-    let word128 = Arc::new(FinalType::prod(Arc::clone(&word64), Arc::clone(&word64)));
-    let word256 = Arc::new(FinalType::prod(Arc::clone(&word128), Arc::clone(&word128)));
-    let word512 = Arc::new(FinalType::prod(Arc::clone(&word256), Arc::clone(&word256)));
-
-    [
-        word0, word1, word2, word4, word8, word16, word32, word64, word128, word256, word512,
-    ]
-}
-
 impl fmt::Display for FinalType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.display)
@@ -130,89 +102,6 @@ impl Eq for FinalType {}
 impl std::hash::Hash for FinalType {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.tmr.hash(state)
-    }
-}
-
-impl FinalType {
-    pub fn bit_width(&self) -> usize {
-        self.bit_width
-    }
-
-    fn from_var(var: RcVar) -> Result<Arc<FinalType>, Error> {
-        let var = find_root(var);
-        let mut var_borr = var.borrow_mut();
-
-        let existing_type = match var_borr.var {
-            Variable::Free => Type::Unit,
-            Variable::Bound(ref ty, ref mut occurs_check) => {
-                if *occurs_check {
-                    return Err(Error::OccursCheck);
-                }
-                *occurs_check = true;
-                ty.clone()
-            }
-            Variable::EqualTo(..) => unreachable!(),
-            Variable::Finalized(ref done) => return Ok(done.clone()),
-        };
-
-        let (sub1, sub2) = match existing_type {
-            Type::Unit => {
-                let ret = Arc::new(FinalType::unit());
-                var_borr.var = Variable::Finalized(ret.clone());
-                return Ok(ret);
-            }
-            Type::Sum(ref sub1, ref sub2) => (sub1.clone(), sub2.clone()),
-            Type::Product(ref sub1, ref sub2) => (sub1.clone(), sub2.clone()),
-        };
-        drop(var_borr);
-
-        let sub1 = find_root(sub1);
-        let sub2 = find_root(sub2);
-
-        let sub1_borr = sub1.borrow_mut();
-        let final1 = match sub1_borr.var {
-            Variable::Free => {
-                drop(sub1_borr);
-                Arc::new(FinalType::unit())
-            }
-            Variable::Bound(..) => {
-                drop(sub1_borr);
-                FinalType::from_var(sub1.clone())?
-            }
-            Variable::EqualTo(..) => unreachable!(),
-            Variable::Finalized(ref f1) => {
-                let ret = f1.clone();
-                drop(sub1_borr);
-                ret
-            }
-        };
-        // drop(sub1_borr);
-        let sub2_borr = sub2.borrow_mut();
-        let final2 = match sub2_borr.var {
-            Variable::Free => {
-                drop(sub2_borr);
-                Arc::new(FinalType::unit())
-            }
-            Variable::Bound(..) => {
-                drop(sub2_borr);
-                FinalType::from_var(sub2.clone())?
-            }
-            Variable::EqualTo(..) => unreachable!(),
-            Variable::Finalized(ref f2) => {
-                let ret = f2.clone();
-                drop(sub2_borr);
-                ret
-            }
-        };
-        // drop(sub2_borr);
-
-        let ret = match existing_type {
-            Type::Unit => unreachable!(),
-            Type::Sum(..) => Arc::new(FinalType::sum(final1, final2)),
-            Type::Product(..) => Arc::new(FinalType::prod(final1, final2)),
-        };
-        var.borrow_mut().var = Variable::Finalized(ret.clone());
-        Ok(ret)
     }
 }
 
@@ -243,8 +132,8 @@ impl fmt::Debug for Variable {
 }
 
 pub(crate) struct UnificationVar {
-    var: Variable,
-    rank: usize,
+    pub var: Variable,
+    pub rank: usize,
 }
 
 impl fmt::Debug for UnificationVar {
@@ -256,286 +145,17 @@ impl fmt::Debug for UnificationVar {
 pub(crate) type RcVar = Rc<RefCell<UnificationVar>>;
 
 impl UnificationVar {
-    fn free() -> UnificationVar {
+    pub fn free() -> UnificationVar {
         UnificationVar {
             var: Variable::Free,
             rank: 0,
         }
     }
 
-    fn concrete(ty: Type) -> UnificationVar {
+    pub fn concrete(ty: Type) -> UnificationVar {
         UnificationVar {
             var: Variable::Bound(ty, false),
             rank: 0,
         }
     }
-}
-
-fn bind(rcvar: &RcVar, ty: Type) -> Result<(), Error> {
-    // Cloning a `Variable` is cheap, as the nontrivial variants merely
-    // hold `Rc`s
-    let self_var = rcvar.borrow().var.clone();
-    match self_var {
-        Variable::Free => {
-            rcvar.borrow_mut().var = Variable::Bound(ty, false);
-            Ok(())
-        }
-        Variable::EqualTo(..) => unreachable!(
-            "Tried to bind unification variable which was not \
-             the representative of its equivalence class"
-        ),
-        Variable::Finalized(..) => unreachable!(),
-        Variable::Bound(self_ty, _) => match (self_ty, ty) {
-            (Type::Unit, Type::Unit) => Ok(()),
-            (Type::Sum(al1, al2), Type::Sum(be1, be2))
-            | (Type::Product(al1, al2), Type::Product(be1, be2)) => {
-                unify(al1, be1)?;
-                unify(al2, be2)
-            }
-            // FIXME output a sane error
-            _ => {
-                //            (a, b) => {
-                /*
-                let self_s = match a {
-                    Type::Unit => "unit",
-                    Type::Sum(..) => "sum",
-                    Type::Product(..) => "prod",
-                };
-                let b_s = match b {
-                    Type::Unit => "unit",
-                    Type::Sum(..) => "sum",
-                    Type::Product(..) => "prod",
-                };
-                */
-                Err(Error::TypeCheck)
-            }
-        },
-    }
-}
-
-fn find_root(mut node: RcVar) -> RcVar {
-    loop {
-        // Double-assignment needed for pre-NLL borrowck reasons
-        let parent = match node.borrow().var {
-            Variable::EqualTo(ref parent) => Some(parent.clone()),
-            _ => None,
-        };
-        let parent = match parent {
-            Some(x) => x,
-            _ => break node,
-        };
-
-        // Extra scope for pre-NLL borrowck reasons
-        {
-            let parent_borr = parent.borrow();
-            if let Variable::EqualTo(ref grandparent) = parent_borr.var {
-                node.borrow_mut().var = Variable::EqualTo(grandparent.clone());
-            }
-        }
-        node = parent;
-    }
-}
-
-fn unify(mut alpha: RcVar, mut beta: RcVar) -> Result<(), Error> {
-    alpha = find_root(alpha);
-    beta = find_root(beta);
-
-    // Already unified, done
-    if Rc::ptr_eq(&alpha, &beta) {
-        return Ok(());
-    }
-
-    // Adjust ranks for union-find path halving
-    let rank_ord = { alpha.borrow().rank.cmp(&beta.borrow().rank) };
-    match rank_ord {
-        cmp::Ordering::Less => mem::swap(&mut alpha, &mut beta),
-        cmp::Ordering::Equal => alpha.borrow_mut().rank += 1,
-        _ => {}
-    }
-
-    // Do the unification
-    let be_var = {
-        let mut be_borr = beta.borrow_mut();
-        mem::replace(&mut be_borr.var, Variable::EqualTo(alpha.clone()))
-    };
-    match be_var {
-        Variable::Free => {} // nothing to do
-        Variable::Bound(be_type, _) => bind(&alpha, be_type)?,
-        Variable::EqualTo(..) => unreachable!(),
-        Variable::Finalized(..) => unreachable!(),
-    }
-
-    Ok(())
-}
-
-#[derive(Clone, Debug)]
-struct UnificationArrow {
-    source: Rc<RefCell<UnificationVar>>,
-    target: Rc<RefCell<UnificationVar>>,
-}
-
-/// Attach types to all nodes in a program
-pub(crate) fn type_check<Witness, App: Application>(
-    program: UntypedProgram<Witness, App>,
-) -> Result<TypedProgram<Witness, App>, Error> {
-    let vec_nodes = program.0;
-    if vec_nodes.is_empty() {
-        return Ok(TypedProgram(vec![]));
-    }
-
-    let two_0 = Type::Unit.into_rcvar();
-    let two_1 = Type::Sum(two_0.clone(), two_0).into_rcvar();
-    let two_2 = Type::Product(two_1.clone(), two_1.clone()).into_rcvar();
-    let two_4 = Type::Product(two_2.clone(), two_2.clone()).into_rcvar();
-    let two_8 = Type::Product(two_4.clone(), two_4.clone()).into_rcvar();
-    let two_16 = Type::Product(two_8.clone(), two_8.clone()).into_rcvar();
-    let two_32 = Type::Product(two_16.clone(), two_16.clone()).into_rcvar();
-    let two_64 = Type::Product(two_32.clone(), two_32.clone()).into_rcvar();
-    let two_128 = Type::Product(two_64.clone(), two_64.clone()).into_rcvar();
-    let two_256 = Type::Product(two_128.clone(), two_128.clone()).into_rcvar();
-    // pow2s[i] = 2^(2^i)
-    let pow2s = [
-        two_1, two_2, two_4, two_8, two_16, two_32, two_64, two_128, two_256,
-    ];
-
-    let mut rcs = Vec::<Rc<UnificationArrow>>::with_capacity(vec_nodes.len());
-    let mut finals = Vec::<TypedNode<Witness, App>>::with_capacity(vec_nodes.len());
-
-    // Compute most general unifier for all types in the DAG
-    for (idx, program_node) in vec_nodes.iter().enumerate() {
-        let node = UnificationArrow {
-            source: Rc::new(RefCell::new(UnificationVar::free())),
-            target: Rc::new(RefCell::new(UnificationVar::free())),
-        };
-
-        match program_node {
-            Term::Iden => unify(node.source.clone(), node.target.clone())?,
-            Term::Unit => bind(&node.target, Type::Unit)?,
-            Term::InjL(i) => {
-                let i = idx - i;
-                unify(node.source.clone(), rcs[i].source.clone())?;
-                let target_type = Type::Sum(
-                    rcs[i].target.clone(),
-                    Rc::new(RefCell::new(UnificationVar::free())),
-                );
-                bind(&node.target, target_type)?;
-            }
-            Term::InjR(i) => {
-                let i = idx - i;
-                unify(node.source.clone(), rcs[i].source.clone())?;
-                let target_type = Type::Sum(
-                    Rc::new(RefCell::new(UnificationVar::free())),
-                    rcs[i].target.clone(),
-                );
-                bind(&node.target, target_type)?;
-            }
-            Term::Take(i) => {
-                let i = idx - i;
-                unify(node.target.clone(), rcs[i].target.clone())?;
-                let target_type = Type::Product(
-                    rcs[i].source.clone(),
-                    Rc::new(RefCell::new(UnificationVar::free())),
-                );
-                bind(&node.source, target_type)?;
-            }
-            Term::Drop(i) => {
-                let i = idx - i;
-                unify(node.target.clone(), rcs[i].target.clone())?;
-                let target_type = Type::Product(
-                    Rc::new(RefCell::new(UnificationVar::free())),
-                    rcs[i].source.clone(),
-                );
-                bind(&node.source, target_type)?;
-            }
-            Term::Comp(i, j) => {
-                let (i, j) = (idx - i, idx - j);
-                unify(node.source.clone(), rcs[i].source.clone())?;
-                unify(rcs[i].target.clone(), rcs[j].source.clone())?;
-                unify(node.target.clone(), rcs[j].target.clone())?;
-            }
-            Term::Case(i, j) | Term::AssertL(i, j) | Term::AssertR(i, j) => {
-                let (i, j) = (idx - i, idx - j);
-                let var1 = Rc::new(RefCell::new(UnificationVar::free()));
-                let var2 = Rc::new(RefCell::new(UnificationVar::free()));
-                let var3 = Rc::new(RefCell::new(UnificationVar::free()));
-
-                let sum12_ty = Type::Sum(var1.clone(), var2.clone());
-                let sum12_var = Rc::new(RefCell::new(UnificationVar::free()));
-                bind(&sum12_var, sum12_ty)?;
-
-                let source_ty = Type::Product(sum12_var, var3.clone());
-                bind(&node.source, source_ty)?;
-                if let Term::Hidden(..) = vec_nodes[i] {
-                } else {
-                    bind(
-                        &find_root(rcs[i].source.clone()),
-                        Type::Product(var1.clone(), var3.clone()),
-                    )?;
-                    unify(node.target.clone(), rcs[i].target.clone())?;
-                }
-                if let Term::Hidden(..) = vec_nodes[j] {
-                } else {
-                    bind(
-                        &find_root(rcs[j].source.clone()),
-                        Type::Product(var2.clone(), var3.clone()),
-                    )?;
-                    unify(node.target.clone(), rcs[j].target.clone())?;
-                }
-            }
-            Term::Pair(i, j) => {
-                let (i, j) = (idx - i, idx - j);
-                unify(node.source.clone(), rcs[i].source.clone())?;
-                unify(node.source.clone(), rcs[j].source.clone())?;
-                bind(
-                    &node.target,
-                    Type::Product(rcs[i].target.clone(), rcs[j].target.clone()),
-                )?;
-            }
-            Term::Disconnect(i, j) => {
-                let (i, j) = (idx - i, idx - j);
-                // See chapter 6 (Delegation) of TR
-                // Be careful, this order changed! https://github.com/ElementsProject/simplicity/pull/46
-                let var_a = Rc::new(RefCell::new(UnificationVar::free()));
-                let var_b = Rc::new(RefCell::new(UnificationVar::free()));
-                let var_c = Rc::new(RefCell::new(UnificationVar::free()));
-                let var_d = Rc::new(RefCell::new(UnificationVar::free()));
-
-                let s_source = Type::Product(pow2s[8].clone(), var_a.clone()).into_rcvar();
-                let s_target = Type::Product(var_b.clone(), var_c.clone()).into_rcvar();
-                unify(rcs[i].source.clone(), s_source)?;
-                unify(rcs[i].target.clone(), s_target)?;
-
-                let node_target = Type::Product(var_b, var_d.clone()).into_rcvar();
-                unify(node.source.clone(), var_a)?;
-                unify(node.target.clone(), node_target)?;
-
-                unify(rcs[j].source.clone(), var_c)?;
-                unify(rcs[j].target.clone(), var_d)?;
-            }
-            Term::Jet(jet) => {
-                bind(&node.source, jet.source_ty.to_type(&pow2s[..]))?;
-
-                bind(&node.target, jet.target_ty.to_type(&pow2s[..]))?;
-            }
-            Term::Witness(..) | Term::Hidden(..) | Term::Fail(..) => {
-                // No type constraints
-            }
-        };
-        rcs.push(Rc::new(node));
-        // dbg!(&rcs);
-    }
-
-    // Finalize, setting all unconstrained types to `Unit` and doing the
-    // occurs check. (All the magic happens inside `FinalType::from_var`.)
-    for (index, term) in vec_nodes.into_iter().enumerate() {
-        finals.push(TypedNode {
-            cmr: cmr::compute_cmr(&finals, &term, index),
-            term,
-            source_ty: FinalType::from_var(rcs[index].source.clone())?,
-            target_ty: FinalType::from_var(rcs[index].target.clone())?,
-            index,
-        });
-    }
-
-    Ok(TypedProgram(finals))
 }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -18,7 +18,7 @@
 //! Refer to [`crate::encode`] for information on the encoding.
 
 use crate::bititer::BitIter;
-use crate::core::types::{FinalType, FinalTypeInner};
+use crate::core::types::{Type, TypeInner};
 use crate::core::{Term, TypedProgram, UntypedProgram, Value};
 use crate::jet::Application;
 use crate::merkle::cmr::Cmr;
@@ -78,18 +78,15 @@ pub fn decode_witness<Wit, App: Application, I: Iterator<Item = u8>>(
 }
 
 /// Decode a value from bits, based on the given type.
-pub fn decode_value<I: Iterator<Item = bool>>(
-    ty: &FinalType,
-    iter: &mut I,
-) -> Result<Value, Error> {
+pub fn decode_value<I: Iterator<Item = bool>>(ty: &Type, iter: &mut I) -> Result<Value, Error> {
     let value = match ty.ty {
-        FinalTypeInner::Unit => Value::Unit,
-        FinalTypeInner::Sum(ref l, ref r) => match iter.next() {
+        TypeInner::Unit => Value::Unit,
+        TypeInner::Sum(ref l, ref r) => match iter.next() {
             Some(false) => Value::SumL(Box::new(decode_value(l, iter)?)),
             Some(true) => Value::SumR(Box::new(decode_value(r, iter)?)),
             None => return Err(Error::EndOfStream),
         },
-        FinalTypeInner::Product(ref l, ref r) => Value::Prod(
+        TypeInner::Product(ref l, ref r) => Value::Prod(
             Box::new(decode_value(l, iter)?),
             Box::new(decode_value(r, iter)?),
         ),

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -7,108 +7,101 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::{cmp, mem};
 
-fn find_root(mut node: RcVar) -> RcVar {
+/// Find the representative of the set of variable `x`
+/// using _path halving_ of the union-find algorithm.
+fn find_root(mut x: RcVar) -> RcVar {
     loop {
-        // Double-assignment needed for pre-NLL borrowck reasons
-        let parent = match node.borrow().inner {
-            VariableInner::EqualTo(ref parent) => Some(parent.clone()),
-            _ => None,
-        };
-        let parent = match parent {
-            Some(x) => x,
-            _ => break node,
+        // Clone inner to un-borrow `x`
+        let x_var = x.borrow().inner.clone();
+        let parent = if let VariableInner::EqualTo(parent) = x_var {
+            parent
+        } else {
+            // If there is no parent, then return the current node.
+            return x;
         };
 
-        // Extra scope for pre-NLL borrowck reasons
-        {
-            let parent_borr = parent.borrow();
-            if let VariableInner::EqualTo(ref grandparent) = parent_borr.inner {
-                node.borrow_mut().inner = VariableInner::EqualTo(grandparent.clone());
-            }
+        // Clone inner to un-borrow `parent`
+        let parent_var = parent.borrow().inner.clone();
+        if let VariableInner::EqualTo(grandparent) = parent_var {
+            // Update the parent pointer to the grandparent, and go to the grandparent.
+            x.borrow_mut().inner = VariableInner::EqualTo(grandparent.clone());
+            x = grandparent;
+        } else {
+            // If there is no grandparent, then return the parent.
+            return parent;
         }
-        node = parent;
     }
 }
 
-fn unify(mut alpha: RcVar, mut beta: RcVar) -> Result<(), Error> {
-    alpha = find_root(alpha);
-    beta = find_root(beta);
+/// Unify the sets of variables `x` and `y`
+/// using _union by rank_ of the union-find algorithm.
+fn unify(mut x: RcVar, mut y: RcVar) -> Result<(), Error> {
+    x = find_root(x);
+    y = find_root(y);
 
-    // Already unified, done
-    if Rc::ptr_eq(&alpha, &beta) {
+    // x and y are already in the same set
+    if Rc::ptr_eq(&x, &y) {
         return Ok(());
     }
 
     // Adjust ranks for union-find path halving
-    let rank_ord = { alpha.borrow().rank.cmp(&beta.borrow().rank) };
+    let rank_ord = x.borrow().rank.cmp(&y.borrow().rank);
     match rank_ord {
-        cmp::Ordering::Less => mem::swap(&mut alpha, &mut beta),
-        cmp::Ordering::Equal => alpha.borrow_mut().rank += 1,
+        // If x.rank < y.rank, then swap x and y to ensure x.rank ≥ y.rank
+        // Always unify tree with smaller rank into tree with larger rank
+        cmp::Ordering::Less => mem::swap(&mut x, &mut y),
+        // If x.rank = y.rank, then increment the rank of x
+        // The rank of x increases by making y its child
+        cmp::Ordering::Equal => x.borrow_mut().rank += 1,
         _ => {}
     }
 
-    // Do the unification
-    let be_var = {
-        let mut be_borr = beta.borrow_mut();
-        mem::replace(&mut be_borr.inner, VariableInner::EqualTo(alpha.clone()))
-    };
-    match be_var {
-        VariableInner::Free(_) => {} // nothing to do
-        VariableInner::Bound(be_type, _) => bind(&alpha, be_type)?,
-        VariableInner::EqualTo(..) => unreachable!(),
-        VariableInner::Finalized(..) => unreachable!(),
+    // Make x the parent of y
+    let old_y_var = mem::replace(&mut y.borrow_mut().inner, VariableInner::EqualTo(x.clone()));
+    match old_y_var {
+        VariableInner::Free(_) => Ok(()),
+        // If y was already bound to a type, then x must be bound, too
+        VariableInner::Bound(be_type, _) => bind(&x, be_type),
+        VariableInner::EqualTo(..) => unreachable!("A root node cannot have a parent"),
+        VariableInner::Finalized(..) => unreachable!("No finalized types at this stage"),
     }
-
-    Ok(())
 }
 
-fn bind(rcvar: &RcVar, ty: VariableType) -> Result<(), Error> {
-    // Cloning a `Variable` is cheap, as the nontrivial variants merely
-    // hold `Rc`s
-    let self_var = rcvar.borrow().inner.clone();
-    match self_var {
+/// Bind variable `x` to type `ty`.
+///
+/// Fails if `x` is already bound to a type that is incompatible with `ty`.
+fn bind(x: &RcVar, ty: VariableType) -> Result<(), Error> {
+    // Clone inner to un-borrow `x`
+    let x_var = x.borrow().inner.clone();
+    match x_var {
         VariableInner::Free(_) => {
-            rcvar.borrow_mut().inner = VariableInner::Bound(ty, false);
+            x.borrow_mut().inner = VariableInner::Bound(ty, false);
             Ok(())
         }
-        VariableInner::EqualTo(..) => unreachable!(
-            "Tried to bind unification variable which was not \
-             the representative of its equivalence class"
-        ),
-        VariableInner::Finalized(..) => unreachable!(),
         VariableInner::Bound(self_ty, _) => match (self_ty, ty) {
             (VariableType::Unit, VariableType::Unit) => Ok(()),
-            (VariableType::Sum(al1, al2), VariableType::Sum(be1, be2))
-            | (VariableType::Product(al1, al2), VariableType::Product(be1, be2)) => {
-                unify(al1, be1)?;
-                unify(al2, be2)
+            (VariableType::Sum(x1, x2), VariableType::Sum(y1, y2))
+            | (VariableType::Product(x1, x2), VariableType::Product(y1, y2)) => {
+                unify(x1, y1)?;
+                unify(x2, y2)
             }
-            // FIXME output a sane error
-            _ => {
-                //            (a, b) => {
-                /*
-                let self_s = match a {
-                    Type::Unit => "unit",
-                    Type::Sum(..) => "sum",
-                    Type::Product(..) => "prod",
-                };
-                let b_s = match b {
-                    Type::Unit => "unit",
-                    Type::Sum(..) => "sum",
-                    Type::Product(..) => "prod",
-                };
-                */
-                Err(Error::TypeCheck)
-            }
+            _ => Err(Error::TypeCheck),
         },
+        VariableInner::EqualTo(..) => unreachable!("Can only bind root nodes"),
+        VariableInner::Finalized(..) => unreachable!("No finalized types at this stage"),
     }
 }
 
-fn finalize(var: RcVar) -> Result<Arc<Type>, Error> {
-    let var = find_root(var);
-    let mut var_borr = var.borrow_mut();
+/// Converts variable `x` into a finalized type.
+///
+/// Free variables are finalized as _unit_.
+/// Bound variables are recursively finalized as the units, sums and products of their types.
+///
+/// Fails if a variable occurs recursively in the type it is bound to _(occurs check)_.
+fn finalize(x: RcVar) -> Result<Arc<Type>, Error> {
+    let x = find_root(x);
 
-    let existing_type = match var_borr.inner {
+    let variable_type = match x.borrow_mut().inner {
         VariableInner::Free(_) => VariableType::Unit,
         VariableInner::Bound(ref ty, ref mut occurs_check) => {
             if *occurs_check {
@@ -117,73 +110,26 @@ fn finalize(var: RcVar) -> Result<Arc<Type>, Error> {
             *occurs_check = true;
             ty.clone()
         }
-        VariableInner::EqualTo(..) => unreachable!(),
-        VariableInner::Finalized(ref done) => return Ok(done.clone()),
+        VariableInner::EqualTo(..) => unreachable!("A root cannot have a parent"),
+        VariableInner::Finalized(ref final_type) => return Ok(final_type.clone()),
     };
 
-    let (sub1, sub2) = match existing_type {
-        VariableType::Unit => {
-            let ret = Type::unit();
-            var_borr.inner = VariableInner::Finalized(ret.clone());
-            return Ok(ret);
-        }
-        VariableType::Sum(ref sub1, ref sub2) => (sub1.clone(), sub2.clone()),
-        VariableType::Product(ref sub1, ref sub2) => (sub1.clone(), sub2.clone()),
+    let final_type = match variable_type {
+        VariableType::Unit => Type::unit(),
+        VariableType::Sum(y, z) => Type::sum(finalize(y)?, finalize(z)?),
+        VariableType::Product(y, z) => Type::product(finalize(y)?, finalize(z)?),
     };
-    drop(var_borr);
 
-    let sub1 = find_root(sub1);
-    let sub2 = find_root(sub2);
-
-    let sub1_borr = sub1.borrow_mut();
-    let final1 = match sub1_borr.inner {
-        VariableInner::Free(_) => {
-            drop(sub1_borr);
-            Type::unit()
-        }
-        VariableInner::Bound(..) => {
-            drop(sub1_borr);
-            finalize(sub1.clone())?
-        }
-        VariableInner::EqualTo(..) => unreachable!(),
-        VariableInner::Finalized(ref f1) => {
-            let ret = f1.clone();
-            drop(sub1_borr);
-            ret
-        }
-    };
-    // drop(sub1_borr);
-    let sub2_borr = sub2.borrow_mut();
-    let final2 = match sub2_borr.inner {
-        VariableInner::Free(_) => {
-            drop(sub2_borr);
-            Type::unit()
-        }
-        VariableInner::Bound(..) => {
-            drop(sub2_borr);
-            finalize(sub2.clone())?
-        }
-        VariableInner::EqualTo(..) => unreachable!(),
-        VariableInner::Finalized(ref f2) => {
-            let ret = f2.clone();
-            drop(sub2_borr);
-            ret
-        }
-    };
-    // drop(sub2_borr);
-
-    let ret = match existing_type {
-        VariableType::Unit => unreachable!(),
-        VariableType::Sum(..) => Type::sum(final1, final2),
-        VariableType::Product(..) => Type::product(final1, final2),
-    };
-    var.borrow_mut().inner = VariableInner::Finalized(ret.clone());
-    Ok(ret)
+    x.borrow_mut().inner = VariableInner::Finalized(final_type.clone());
+    Ok(final_type)
 }
 
+/// Reference to the source and target type of a node during type inference
 #[derive(Clone, Debug)]
 struct UnificationArrow {
+    /// Source type of the node
     source: RcVar,
+    /// Target type of the node
     target: RcVar,
 }
 
@@ -191,140 +137,159 @@ struct UnificationArrow {
 pub(crate) fn type_check<Witness, App: Application>(
     program: UntypedProgram<Witness, App>,
 ) -> Result<TypedProgram<Witness, App>, Error> {
-    let vec_nodes = program.0;
-    if vec_nodes.is_empty() {
+    let nodes = program.0;
+    if nodes.is_empty() {
         return Ok(TypedProgram(vec![]));
     }
 
-    let mut rcs = Vec::<Rc<UnificationArrow>>::with_capacity(vec_nodes.len());
-    let mut finals = Vec::<TypedNode<Witness, App>>::with_capacity(vec_nodes.len());
+    let mut arrows: Vec<UnificationArrow> = Vec::with_capacity(nodes.len());
     let pow2s = Variable::powers_of_two();
     let mut naming = VariableFactory::new();
 
-    // Compute most general unifier for all types in the DAG
-    for (idx, program_node) in vec_nodes.iter().enumerate() {
-        let node = UnificationArrow {
+    for (idx, node) in nodes.iter().enumerate() {
+        let arrow = UnificationArrow {
             source: naming.free_variable(),
             target: naming.free_variable(),
         };
 
-        match program_node {
-            Term::Iden => unify(node.source.clone(), node.target.clone())?,
-            Term::Unit => bind(&node.target, VariableType::Unit)?,
+        match node {
+            Term::Iden => unify(arrow.source.clone(), arrow.target.clone())?,
+            Term::Unit => bind(&arrow.target, VariableType::Unit)?,
             Term::InjL(i) => {
                 let i = idx - i;
-                unify(node.source.clone(), rcs[i].source.clone())?;
-                let target_type = VariableType::Sum(rcs[i].target.clone(), naming.free_variable());
-                bind(&node.target, target_type)?;
+                unify(arrow.source.clone(), arrows[i].source.clone())?;
+                let sum_b_c = VariableType::Sum(arrows[i].target.clone(), naming.free_variable());
+                bind(&arrow.target, sum_b_c)?;
             }
             Term::InjR(i) => {
                 let i = idx - i;
-                unify(node.source.clone(), rcs[i].source.clone())?;
-                let target_type = VariableType::Sum(naming.free_variable(), rcs[i].target.clone());
-                bind(&node.target, target_type)?;
+                unify(arrow.source.clone(), arrows[i].source.clone())?;
+                let sum_b_c = VariableType::Sum(naming.free_variable(), arrows[i].target.clone());
+                bind(&arrow.target, sum_b_c)?;
             }
             Term::Take(i) => {
                 let i = idx - i;
-                unify(node.target.clone(), rcs[i].target.clone())?;
-                let target_type =
-                    VariableType::Product(rcs[i].source.clone(), naming.free_variable());
-                bind(&node.source, target_type)?;
+                unify(arrow.target.clone(), arrows[i].target.clone())?;
+                let prod_a_b =
+                    VariableType::Product(arrows[i].source.clone(), naming.free_variable());
+                bind(&arrow.source, prod_a_b)?;
             }
             Term::Drop(i) => {
                 let i = idx - i;
-                unify(node.target.clone(), rcs[i].target.clone())?;
-                let target_type =
-                    VariableType::Product(naming.free_variable(), rcs[i].source.clone());
-                bind(&node.source, target_type)?;
+                unify(arrow.target.clone(), arrows[i].target.clone())?;
+                let prod_a_b =
+                    VariableType::Product(naming.free_variable(), arrows[i].source.clone());
+                bind(&arrow.source, prod_a_b)?;
             }
             Term::Comp(i, j) => {
                 let (i, j) = (idx - i, idx - j);
-                unify(node.source.clone(), rcs[i].source.clone())?;
-                unify(rcs[i].target.clone(), rcs[j].source.clone())?;
-                unify(node.target.clone(), rcs[j].target.clone())?;
+                unify(arrow.source.clone(), arrows[i].source.clone())?;
+                unify(arrows[i].target.clone(), arrows[j].source.clone())?;
+                unify(arrow.target.clone(), arrows[j].target.clone())?;
             }
             Term::Case(i, j) | Term::AssertL(i, j) | Term::AssertR(i, j) => {
                 let (i, j) = (idx - i, idx - j);
-                let var1 = naming.free_variable();
-                let var2 = naming.free_variable();
-                let var3 = naming.free_variable();
+                let a = naming.free_variable();
+                let b = naming.free_variable();
+                let c = naming.free_variable();
 
-                let sum12_ty = VariableType::Sum(var1.clone(), var2.clone());
-                let sum12_var = naming.free_variable();
-                bind(&sum12_var, sum12_ty)?;
+                let sum_a_b = VariableType::Sum(a.clone(), b.clone());
+                let prod_sum_a_b_c = VariableType::Product(Variable::bound(sum_a_b), c.clone());
+                bind(&arrow.source, prod_sum_a_b_c)?;
 
-                let source_ty = VariableType::Product(sum12_var, var3.clone());
-                bind(&node.source, source_ty)?;
-                if let Term::Hidden(..) = vec_nodes[i] {
+                if let Term::AssertR(..) = node {
                 } else {
                     bind(
-                        &find_root(rcs[i].source.clone()),
-                        VariableType::Product(var1.clone(), var3.clone()),
+                        &find_root(arrows[i].source.clone()),
+                        VariableType::Product(a.clone(), c.clone()),
                     )?;
-                    unify(node.target.clone(), rcs[i].target.clone())?;
+                    unify(arrow.target.clone(), arrows[i].target.clone())?;
                 }
-                if let Term::Hidden(..) = vec_nodes[j] {
+                if let Term::AssertL(..) = node {
                 } else {
                     bind(
-                        &find_root(rcs[j].source.clone()),
-                        VariableType::Product(var2.clone(), var3.clone()),
+                        &find_root(arrows[j].source.clone()),
+                        VariableType::Product(b.clone(), c.clone()),
                     )?;
-                    unify(node.target.clone(), rcs[j].target.clone())?;
+                    unify(arrow.target.clone(), arrows[j].target.clone())?;
                 }
             }
             Term::Pair(i, j) => {
                 let (i, j) = (idx - i, idx - j);
-                unify(node.source.clone(), rcs[i].source.clone())?;
-                unify(node.source.clone(), rcs[j].source.clone())?;
+                unify(arrow.source.clone(), arrows[i].source.clone())?;
+                unify(arrow.source.clone(), arrows[j].source.clone())?;
                 bind(
-                    &node.target,
-                    VariableType::Product(rcs[i].target.clone(), rcs[j].target.clone()),
+                    &arrow.target,
+                    VariableType::Product(arrows[i].target.clone(), arrows[j].target.clone()),
                 )?;
             }
             Term::Disconnect(i, j) => {
                 let (i, j) = (idx - i, idx - j);
-                // See chapter 6 (Delegation) of TR
-                // Be careful, this order changed! https://github.com/ElementsProject/simplicity/pull/46
-                let var_a = naming.free_variable();
-                let var_b = naming.free_variable();
-                let var_c = naming.free_variable();
-                let var_d = naming.free_variable();
+                let a = naming.free_variable();
+                let b = naming.free_variable();
+                let c = naming.free_variable();
+                let d = naming.free_variable();
 
-                let s_source =
-                    Variable::bound(VariableType::Product(pow2s[8].clone(), var_a.clone()));
-                let s_target = Variable::bound(VariableType::Product(var_b.clone(), var_c.clone()));
-                unify(rcs[i].source.clone(), s_source)?;
-                unify(rcs[i].target.clone(), s_target)?;
+                let prod_256_a =
+                    Variable::bound(VariableType::Product(pow2s[8].clone(), a.clone()));
+                let prod_b_c = Variable::bound(VariableType::Product(b.clone(), c.clone()));
+                unify(arrows[i].source.clone(), prod_256_a)?;
+                unify(arrows[i].target.clone(), prod_b_c)?;
+                unify(arrows[j].source.clone(), c)?;
+                unify(arrows[j].target.clone(), d.clone())?;
 
-                let node_target = Variable::bound(VariableType::Product(var_b, var_d.clone()));
-                unify(node.source.clone(), var_a)?;
-                unify(node.target.clone(), node_target)?;
-
-                unify(rcs[j].source.clone(), var_c)?;
-                unify(rcs[j].target.clone(), var_d)?;
+                let prod_b_d = Variable::bound(VariableType::Product(b, d));
+                unify(arrow.source.clone(), a)?;
+                unify(arrow.target.clone(), prod_b_d)?;
             }
             Term::Jet(jet) => {
-                bind(&node.source, jet.source_ty.to_type(&pow2s[..]))?;
-
-                bind(&node.target, jet.target_ty.to_type(&pow2s[..]))?;
+                bind(&arrow.source, jet.source_ty.to_type(&pow2s))?;
+                bind(&arrow.target, jet.target_ty.to_type(&pow2s))?;
             }
             Term::Witness(..) | Term::Hidden(..) | Term::Fail(..) => {
                 // No type constraints
             }
-        };
-        rcs.push(Rc::new(node));
-        // dbg!(&rcs);
+        }
+
+        arrows.push(arrow);
     }
 
-    for (index, term) in vec_nodes.into_iter().enumerate() {
-        finals.push(TypedNode {
-            cmr: cmr::compute_cmr(&finals, &term, index),
+    let mut typed_nodes = Vec::with_capacity(nodes.len());
+
+    for (index, term) in nodes.into_iter().enumerate() {
+        typed_nodes.push(TypedNode {
+            cmr: cmr::compute_cmr(&typed_nodes, &term, index),
             term,
-            source_ty: finalize(rcs[index].source.clone())?,
-            target_ty: finalize(rcs[index].target.clone())?,
+            source_ty: finalize(arrows[index].source.clone())?,
+            target_ty: finalize(arrows[index].target.clone())?,
             index,
         });
     }
 
-    Ok(TypedProgram(finals))
+    Ok(TypedProgram(typed_nodes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::types::Variable;
+
+    #[test]
+    fn type_error() {
+        let mut naming = VariableFactory::new();
+        let pow2s = Variable::powers_of_two();
+        let x = naming.free_variable();
+        let y = naming.free_variable();
+
+        let x1 = naming.free_variable();
+        let x2 = naming.free_variable();
+        bind(&x, VariableType::Sum(x1, x2)).unwrap();
+        bind(
+            &y,
+            VariableType::Product(pow2s[8].clone(), naming.free_variable()),
+        )
+        .unwrap();
+
+        unify(x, y).unwrap_err();
+    }
 }

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -1,0 +1,353 @@
+use crate::core::types::{FinalType, RcVar, Type, UnificationVar, Variable};
+use crate::core::{Term, TypedNode, TypedProgram, UntypedProgram};
+use crate::jet::Application;
+use crate::merkle::cmr;
+use crate::Error;
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::{cmp, mem};
+
+fn find_root(mut node: RcVar) -> RcVar {
+    loop {
+        // Double-assignment needed for pre-NLL borrowck reasons
+        let parent = match node.borrow().var {
+            Variable::EqualTo(ref parent) => Some(parent.clone()),
+            _ => None,
+        };
+        let parent = match parent {
+            Some(x) => x,
+            _ => break node,
+        };
+
+        // Extra scope for pre-NLL borrowck reasons
+        {
+            let parent_borr = parent.borrow();
+            if let Variable::EqualTo(ref grandparent) = parent_borr.var {
+                node.borrow_mut().var = Variable::EqualTo(grandparent.clone());
+            }
+        }
+        node = parent;
+    }
+}
+
+fn unify(mut alpha: RcVar, mut beta: RcVar) -> Result<(), Error> {
+    alpha = find_root(alpha);
+    beta = find_root(beta);
+
+    // Already unified, done
+    if Rc::ptr_eq(&alpha, &beta) {
+        return Ok(());
+    }
+
+    // Adjust ranks for union-find path halving
+    let rank_ord = { alpha.borrow().rank.cmp(&beta.borrow().rank) };
+    match rank_ord {
+        cmp::Ordering::Less => mem::swap(&mut alpha, &mut beta),
+        cmp::Ordering::Equal => alpha.borrow_mut().rank += 1,
+        _ => {}
+    }
+
+    // Do the unification
+    let be_var = {
+        let mut be_borr = beta.borrow_mut();
+        mem::replace(&mut be_borr.var, Variable::EqualTo(alpha.clone()))
+    };
+    match be_var {
+        Variable::Free => {} // nothing to do
+        Variable::Bound(be_type, _) => bind(&alpha, be_type)?,
+        Variable::EqualTo(..) => unreachable!(),
+        Variable::Finalized(..) => unreachable!(),
+    }
+
+    Ok(())
+}
+
+fn bind(rcvar: &RcVar, ty: Type) -> Result<(), Error> {
+    // Cloning a `Variable` is cheap, as the nontrivial variants merely
+    // hold `Rc`s
+    let self_var = rcvar.borrow().var.clone();
+    match self_var {
+        Variable::Free => {
+            rcvar.borrow_mut().var = Variable::Bound(ty, false);
+            Ok(())
+        }
+        Variable::EqualTo(..) => unreachable!(
+            "Tried to bind unification variable which was not \
+             the representative of its equivalence class"
+        ),
+        Variable::Finalized(..) => unreachable!(),
+        Variable::Bound(self_ty, _) => match (self_ty, ty) {
+            (Type::Unit, Type::Unit) => Ok(()),
+            (Type::Sum(al1, al2), Type::Sum(be1, be2))
+            | (Type::Product(al1, al2), Type::Product(be1, be2)) => {
+                unify(al1, be1)?;
+                unify(al2, be2)
+            }
+            // FIXME output a sane error
+            _ => {
+                //            (a, b) => {
+                /*
+                let self_s = match a {
+                    Type::Unit => "unit",
+                    Type::Sum(..) => "sum",
+                    Type::Product(..) => "prod",
+                };
+                let b_s = match b {
+                    Type::Unit => "unit",
+                    Type::Sum(..) => "sum",
+                    Type::Product(..) => "prod",
+                };
+                */
+                Err(Error::TypeCheck)
+            }
+        },
+    }
+}
+
+fn finalize(var: RcVar) -> Result<Arc<FinalType>, Error> {
+    let var = find_root(var);
+    let mut var_borr = var.borrow_mut();
+
+    let existing_type = match var_borr.var {
+        Variable::Free => Type::Unit,
+        Variable::Bound(ref ty, ref mut occurs_check) => {
+            if *occurs_check {
+                return Err(Error::OccursCheck);
+            }
+            *occurs_check = true;
+            ty.clone()
+        }
+        Variable::EqualTo(..) => unreachable!(),
+        Variable::Finalized(ref done) => return Ok(done.clone()),
+    };
+
+    let (sub1, sub2) = match existing_type {
+        Type::Unit => {
+            let ret = Arc::new(FinalType::unit());
+            var_borr.var = Variable::Finalized(ret.clone());
+            return Ok(ret);
+        }
+        Type::Sum(ref sub1, ref sub2) => (sub1.clone(), sub2.clone()),
+        Type::Product(ref sub1, ref sub2) => (sub1.clone(), sub2.clone()),
+    };
+    drop(var_borr);
+
+    let sub1 = find_root(sub1);
+    let sub2 = find_root(sub2);
+
+    let sub1_borr = sub1.borrow_mut();
+    let final1 = match sub1_borr.var {
+        Variable::Free => {
+            drop(sub1_borr);
+            Arc::new(FinalType::unit())
+        }
+        Variable::Bound(..) => {
+            drop(sub1_borr);
+            finalize(sub1.clone())?
+        }
+        Variable::EqualTo(..) => unreachable!(),
+        Variable::Finalized(ref f1) => {
+            let ret = f1.clone();
+            drop(sub1_borr);
+            ret
+        }
+    };
+    // drop(sub1_borr);
+    let sub2_borr = sub2.borrow_mut();
+    let final2 = match sub2_borr.var {
+        Variable::Free => {
+            drop(sub2_borr);
+            Arc::new(FinalType::unit())
+        }
+        Variable::Bound(..) => {
+            drop(sub2_borr);
+            finalize(sub2.clone())?
+        }
+        Variable::EqualTo(..) => unreachable!(),
+        Variable::Finalized(ref f2) => {
+            let ret = f2.clone();
+            drop(sub2_borr);
+            ret
+        }
+    };
+    // drop(sub2_borr);
+
+    let ret = match existing_type {
+        Type::Unit => unreachable!(),
+        Type::Sum(..) => Arc::new(FinalType::sum(final1, final2)),
+        Type::Product(..) => Arc::new(FinalType::prod(final1, final2)),
+    };
+    var.borrow_mut().var = Variable::Finalized(ret.clone());
+    Ok(ret)
+}
+
+#[derive(Clone, Debug)]
+struct UnificationArrow {
+    source: Rc<RefCell<UnificationVar>>,
+    target: Rc<RefCell<UnificationVar>>,
+}
+
+/// Attach types to all nodes in a program
+pub(crate) fn type_check<Witness, App: Application>(
+    program: UntypedProgram<Witness, App>,
+) -> Result<TypedProgram<Witness, App>, Error> {
+    let vec_nodes = program.0;
+    if vec_nodes.is_empty() {
+        return Ok(TypedProgram(vec![]));
+    }
+
+    let two_0 = Type::Unit.into_rcvar();
+    let two_1 = Type::Sum(two_0.clone(), two_0).into_rcvar();
+    let two_2 = Type::Product(two_1.clone(), two_1.clone()).into_rcvar();
+    let two_4 = Type::Product(two_2.clone(), two_2.clone()).into_rcvar();
+    let two_8 = Type::Product(two_4.clone(), two_4.clone()).into_rcvar();
+    let two_16 = Type::Product(two_8.clone(), two_8.clone()).into_rcvar();
+    let two_32 = Type::Product(two_16.clone(), two_16.clone()).into_rcvar();
+    let two_64 = Type::Product(two_32.clone(), two_32.clone()).into_rcvar();
+    let two_128 = Type::Product(two_64.clone(), two_64.clone()).into_rcvar();
+    let two_256 = Type::Product(two_128.clone(), two_128.clone()).into_rcvar();
+    // pow2s[i] = 2^(2^i)
+    let pow2s = [
+        two_1, two_2, two_4, two_8, two_16, two_32, two_64, two_128, two_256,
+    ];
+
+    let mut rcs = Vec::<Rc<UnificationArrow>>::with_capacity(vec_nodes.len());
+    let mut finals = Vec::<TypedNode<Witness, App>>::with_capacity(vec_nodes.len());
+
+    // Compute most general unifier for all types in the DAG
+    for (idx, program_node) in vec_nodes.iter().enumerate() {
+        let node = UnificationArrow {
+            source: Rc::new(RefCell::new(UnificationVar::free())),
+            target: Rc::new(RefCell::new(UnificationVar::free())),
+        };
+
+        match program_node {
+            Term::Iden => unify(node.source.clone(), node.target.clone())?,
+            Term::Unit => bind(&node.target, Type::Unit)?,
+            Term::InjL(i) => {
+                let i = idx - i;
+                unify(node.source.clone(), rcs[i].source.clone())?;
+                let target_type = Type::Sum(
+                    rcs[i].target.clone(),
+                    Rc::new(RefCell::new(UnificationVar::free())),
+                );
+                bind(&node.target, target_type)?;
+            }
+            Term::InjR(i) => {
+                let i = idx - i;
+                unify(node.source.clone(), rcs[i].source.clone())?;
+                let target_type = Type::Sum(
+                    Rc::new(RefCell::new(UnificationVar::free())),
+                    rcs[i].target.clone(),
+                );
+                bind(&node.target, target_type)?;
+            }
+            Term::Take(i) => {
+                let i = idx - i;
+                unify(node.target.clone(), rcs[i].target.clone())?;
+                let target_type = Type::Product(
+                    rcs[i].source.clone(),
+                    Rc::new(RefCell::new(UnificationVar::free())),
+                );
+                bind(&node.source, target_type)?;
+            }
+            Term::Drop(i) => {
+                let i = idx - i;
+                unify(node.target.clone(), rcs[i].target.clone())?;
+                let target_type = Type::Product(
+                    Rc::new(RefCell::new(UnificationVar::free())),
+                    rcs[i].source.clone(),
+                );
+                bind(&node.source, target_type)?;
+            }
+            Term::Comp(i, j) => {
+                let (i, j) = (idx - i, idx - j);
+                unify(node.source.clone(), rcs[i].source.clone())?;
+                unify(rcs[i].target.clone(), rcs[j].source.clone())?;
+                unify(node.target.clone(), rcs[j].target.clone())?;
+            }
+            Term::Case(i, j) | Term::AssertL(i, j) | Term::AssertR(i, j) => {
+                let (i, j) = (idx - i, idx - j);
+                let var1 = Rc::new(RefCell::new(UnificationVar::free()));
+                let var2 = Rc::new(RefCell::new(UnificationVar::free()));
+                let var3 = Rc::new(RefCell::new(UnificationVar::free()));
+
+                let sum12_ty = Type::Sum(var1.clone(), var2.clone());
+                let sum12_var = Rc::new(RefCell::new(UnificationVar::free()));
+                bind(&sum12_var, sum12_ty)?;
+
+                let source_ty = Type::Product(sum12_var, var3.clone());
+                bind(&node.source, source_ty)?;
+                if let Term::Hidden(..) = vec_nodes[i] {
+                } else {
+                    bind(
+                        &find_root(rcs[i].source.clone()),
+                        Type::Product(var1.clone(), var3.clone()),
+                    )?;
+                    unify(node.target.clone(), rcs[i].target.clone())?;
+                }
+                if let Term::Hidden(..) = vec_nodes[j] {
+                } else {
+                    bind(
+                        &find_root(rcs[j].source.clone()),
+                        Type::Product(var2.clone(), var3.clone()),
+                    )?;
+                    unify(node.target.clone(), rcs[j].target.clone())?;
+                }
+            }
+            Term::Pair(i, j) => {
+                let (i, j) = (idx - i, idx - j);
+                unify(node.source.clone(), rcs[i].source.clone())?;
+                unify(node.source.clone(), rcs[j].source.clone())?;
+                bind(
+                    &node.target,
+                    Type::Product(rcs[i].target.clone(), rcs[j].target.clone()),
+                )?;
+            }
+            Term::Disconnect(i, j) => {
+                let (i, j) = (idx - i, idx - j);
+                // See chapter 6 (Delegation) of TR
+                // Be careful, this order changed! https://github.com/ElementsProject/simplicity/pull/46
+                let var_a = Rc::new(RefCell::new(UnificationVar::free()));
+                let var_b = Rc::new(RefCell::new(UnificationVar::free()));
+                let var_c = Rc::new(RefCell::new(UnificationVar::free()));
+                let var_d = Rc::new(RefCell::new(UnificationVar::free()));
+
+                let s_source = Type::Product(pow2s[8].clone(), var_a.clone()).into_rcvar();
+                let s_target = Type::Product(var_b.clone(), var_c.clone()).into_rcvar();
+                unify(rcs[i].source.clone(), s_source)?;
+                unify(rcs[i].target.clone(), s_target)?;
+
+                let node_target = Type::Product(var_b, var_d.clone()).into_rcvar();
+                unify(node.source.clone(), var_a)?;
+                unify(node.target.clone(), node_target)?;
+
+                unify(rcs[j].source.clone(), var_c)?;
+                unify(rcs[j].target.clone(), var_d)?;
+            }
+            Term::Jet(jet) => {
+                bind(&node.source, jet.source_ty.to_type(&pow2s[..]))?;
+
+                bind(&node.target, jet.target_ty.to_type(&pow2s[..]))?;
+            }
+            Term::Witness(..) | Term::Hidden(..) | Term::Fail(..) => {
+                // No type constraints
+            }
+        };
+        rcs.push(Rc::new(node));
+        // dbg!(&rcs);
+    }
+
+    for (index, term) in vec_nodes.into_iter().enumerate() {
+        finals.push(TypedNode {
+            cmr: cmr::compute_cmr(&finals, &term, index),
+            term,
+            source_ty: finalize(rcs[index].source.clone())?,
+            target_ty: finalize(rcs[index].target.clone())?,
+            index,
+        });
+    }
+
+    Ok(TypedProgram(finals))
+}

--- a/src/jet/type_name.rs
+++ b/src/jet/type_name.rs
@@ -16,8 +16,8 @@
 //!
 //! Source and target types of jet nodes need to be specified manually.
 
-use crate::core::types::RcVar;
-use crate::core::types::Type;
+use crate::core::types::VariableType;
+use crate::core::types::{RcVar, Variable};
 
 /// Byte-based specification of a Simplicity type.
 ///
@@ -47,28 +47,28 @@ impl TypeName {
     // b'h' = 104
     // b'+' = 43
     // b'*' = 42
-    /// Convert the [`TypeName`] into a [`Type`]
-    pub(crate) fn to_type(&self, pow2s: &[RcVar]) -> Type {
+    /// Convert the type name into a type.
+    pub(crate) fn to_type(&self, pow2s: &[RcVar]) -> VariableType {
         let it = self.0.iter().rev();
         let mut stack = Vec::new();
 
         for c in it {
             match c {
-                b'1' => stack.push(Type::Unit),
+                b'1' => stack.push(VariableType::Unit),
                 b'2' => {
-                    let unit = Type::Unit.into_rcvar();
-                    stack.push(Type::Sum(unit.clone(), unit))
+                    let unit = Variable::bound(VariableType::Unit);
+                    stack.push(VariableType::Sum(unit.clone(), unit))
                 }
-                b'i' => stack.push(Type::Product(pow2s[4].clone(), pow2s[4].clone())),
-                b'l' => stack.push(Type::Product(pow2s[5].clone(), pow2s[5].clone())),
-                b'h' => stack.push(Type::Product(pow2s[7].clone(), pow2s[7].clone())),
+                b'i' => stack.push(VariableType::Product(pow2s[4].clone(), pow2s[4].clone())),
+                b'l' => stack.push(VariableType::Product(pow2s[5].clone(), pow2s[5].clone())),
+                b'h' => stack.push(VariableType::Product(pow2s[7].clone(), pow2s[7].clone())),
                 b'+' | b'*' => {
-                    let left = stack.pop().expect("Illegal type name syntax!").into_rcvar();
-                    let right = stack.pop().expect("Illegal type name syntax!").into_rcvar();
+                    let left = Variable::bound(stack.pop().expect("Illegal type name syntax!"));
+                    let right = Variable::bound(stack.pop().expect("Illegal type name syntax!"));
 
                     match c {
-                        b'+' => stack.push(Type::Sum(left, right)),
-                        b'*' => stack.push(Type::Product(left, right)),
+                        b'+' => stack.push(VariableType::Sum(left, right)),
+                        b'*' => stack.push(VariableType::Product(left, right)),
                         _ => unreachable!(),
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod bititer;
 pub mod core;
 pub mod decode;
 pub mod encode;
+mod inference;
 pub mod jet;
 pub mod merkle;
 #[cfg(feature = "bitcoin")]

--- a/src/merkle/common.rs
+++ b/src/merkle/common.rs
@@ -14,7 +14,7 @@
 
 //! # Common traits and macros
 
-use crate::core::types::{FinalType, FinalTypeInner};
+use crate::core::types::{Type, TypeInner};
 use crate::core::{Term, Value};
 use crate::jet::Application;
 use crate::util::u64_to_array_be;
@@ -70,7 +70,7 @@ pub trait MerkleRoot: From<[u8; 32]> + Into<[u8; 32]> {
     /// The hash `self` is taken as initial value,
     /// the hash of `value` and the TMR of `value_type` are combined to create a 512-bit block,
     /// and the compression is run once
-    fn update_value(self, value: &Value, value_type: &FinalType) -> Self {
+    fn update_value(self, value: &Value, value_type: &Type) -> Self {
         let (mut bytes, bit_length) = value.to_bytes_len();
 
         // 1 Bit-wise hash of `value`
@@ -132,13 +132,13 @@ pub trait TermMerkleRoot: MerkleRoot {
     fn get_iv<Witness, App: Application>(term: &Term<Witness, App>) -> Self;
 }
 
-/// Tagged SHA256 hash used for [`FinalType`]
+/// Tagged SHA256 hash used for [`Type`]
 pub trait TypeMerkleRoot: MerkleRoot {
-    /// Return the initial value for the given `final_type`.
+    /// Return the initial value for the given type.
     ///
-    /// Each [`FinalType::ty`] corresponds to some tag that is hashed
+    /// Each [`Type::ty`] corresponds to some tag that is hashed
     /// and returned as initial value
-    fn get_iv(ty: &FinalTypeInner) -> Self;
+    fn get_iv(ty: &TypeInner) -> Self;
 }
 
 /// Convenience macro for wrappers of `Midstate`.

--- a/src/merkle/tmr.rs
+++ b/src/merkle/tmr.rs
@@ -17,7 +17,7 @@
 //! Used at time of redemption (see [`super::imr`]).
 //! Uniquely identifies the tree structure of a Simplicity type.
 
-use crate::core::types::FinalTypeInner;
+use crate::core::types::TypeInner;
 use crate::impl_midstate_wrapper;
 use crate::merkle::common::{MerkleRoot, TypeMerkleRoot};
 use bitcoin_hashes::sha256::Midstate;
@@ -29,11 +29,11 @@ pub struct Tmr(Midstate);
 impl_midstate_wrapper!(Tmr);
 
 impl TypeMerkleRoot for Tmr {
-    fn get_iv(ty: &FinalTypeInner) -> Self {
+    fn get_iv(ty: &TypeInner) -> Self {
         match ty {
-            FinalTypeInner::Unit => Tmr::tag_iv(b"Simplicity-Draft\x1fType\x1fone"),
-            FinalTypeInner::Sum(..) => Tmr::tag_iv(b"Simplicity-Draft\x1fType\x1fsum"),
-            FinalTypeInner::Product(..) => Tmr::tag_iv(b"Simplicity-Draft\x1fType\x1fprod"),
+            TypeInner::Unit => Tmr::tag_iv(b"Simplicity-Draft\x1fType\x1fone"),
+            TypeInner::Sum(..) => Tmr::tag_iv(b"Simplicity-Draft\x1fType\x1fsum"),
+            TypeInner::Product(..) => Tmr::tag_iv(b"Simplicity-Draft\x1fType\x1fprod"),
         }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -65,3 +65,25 @@ pub(crate) fn bitvec_to_bytevec(bitvec: &[bool]) -> Vec<u8> {
     }
     ret
 }
+
+/// Replace all occurrences of a `pattern` in a `src` string with a `replacement` string,
+/// and write the result to a `dst` string.
+///
+/// This method does not allocate if `dst` is sufficiently long (e.g., as long as `src`).
+pub(crate) fn replace_to_buffer(src: &str, dst: &mut String, pattern: &str, replacement: &str) {
+    let mut last_index = 0;
+    let len = pattern.len();
+
+    for (index, _) in src.match_indices(pattern) {
+        if last_index < index {
+            dst.push_str(&src[last_index..index])
+        }
+
+        dst.push_str(replacement);
+        last_index = index + len;
+    }
+
+    if last_index < src.len() {
+        dst.push_str(&src[last_index..])
+    }
+}


### PR DESCRIPTION
This PR refactors the type system: Types are kept separate from type inference, identifiers were changed, and documentation was added. The big addition is that variables have `String`s as identifiers and variable types implement `Display` using that. As these types are variable, we cannot use the optimisation of storing formatted strings in the struct. Instead, we create a large string and replace occurrences of powers of two using relatively few allocations. This formatting can be used in a later PR to create helpful type errors.