### PR TITLE
Fix fuzzing

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ cargo-fuzz = true
 honggfuzz_fuzz = ["honggfuzz"]
 
 [dependencies]
-honggfuzz = { version = "0.5", optional = true }
+honggfuzz = { version = "0.5", optional = true, default-features = false }
 simplicity = { path = ".." }
 
 # Prevent this from interfering with workspaces

--- a/fuzz/travis-fuzz.sh
+++ b/fuzz/travis-fuzz.sh
@@ -9,7 +9,7 @@ if [ ${incorrectFilenames} -gt 0 ]; then
 fi
 
 # Testing
-cargo install --force honggfuzz
+cargo install --force honggfuzz --no-default-features
 for TARGET in fuzz_targets/*; do
 	FILENAME=$(basename $TARGET)
 	FILE="${FILENAME%.*}"


### PR DESCRIPTION
Drops honggfuzz dependency `arbitrary` to meet MSRV. `arbitrary` 1.1.3 introduced `array_from_fn`, which is stable from Rust 1.63.0.

See [https://github.com/lightningdevkit/rust-lightning/pull/1687](https://github.com/lightningdevkit/rust-lightning/pull/1687).