### PR TITLE
Policy hotfix

### DIFF
--- a/src/jet/application/bitcoin/decode.rs
+++ b/src/jet/application/bitcoin/decode.rs
@@ -14,7 +14,7 @@ pub(super) fn decode_primitive<I: Iterator<Item = u8>>(
             Some(true) => Ok(&jet::bitcoin::LOCK_TIME),
             None => Err(Error::EndOfStream),
         },
-        1 => Ok(&jet::bitcoin::INPUTS_HASH),
+        1 => Ok(&jet::bitcoin::SIGHASH_ALL),
         2 => Ok(&jet::bitcoin::OUTPUTS_HASH),
         6 => Ok(&jet::bitcoin::CURRENT_VALUE),
         7 => Ok(&jet::bitcoin::CURRENT_SEQUENCE),

--- a/src/jet/application/bitcoin/encode.rs
+++ b/src/jet/application/bitcoin/encode.rs
@@ -12,7 +12,7 @@ pub(super) fn encode_primitive<W: Write>(
     match jet.name {
         BitcoinJetName::Version => w.write_bits_be(64 + 0, 7),
         BitcoinJetName::LockTime => w.write_bits_be(64 + 1, 7),
-        BitcoinJetName::InputsHash => w.write_bits_be(32 + 1, 6),
+        BitcoinJetName::SighashAll => w.write_bits_be(32 + 1, 6),
         BitcoinJetName::OutputsHash => w.write_bits_be(32 + 2, 6),
         BitcoinJetName::NumInputs => w.write_bits_be(32 + 3, 6),
         BitcoinJetName::TotalInputValue => w.write_bits_be(32 + 4, 6),


### PR DESCRIPTION
This PR enables the (de)serialisation of all compiled Simplicity policies. SIGHASH_ALL replaces INPUTS_HASH, because the addition of the former required a corresponding serialisation. In the future, when the Rust jets are brought up to date, all jets will have some serialization, but the concrete bitstrings will change. 