### PR TITLE
Fixup

### DIFF
--- a/fuzz/fuzz_targets/decode_natural.rs
+++ b/fuzz/fuzz_targets/decode_natural.rs
@@ -86,7 +86,9 @@ mod tests {
     #[test]
     fn duplicate_crash() {
         #[cfg(not(fuzzing))]
-        compile_error!("To build this target or run the unit tests you must set RUSTFLAGS=--cfg=fuzzing");
+        compile_error!(
+            "To build this target or run the unit tests you must set RUSTFLAGS=--cfg=fuzzing"
+        );
 
         let mut a = Vec::new();
         extend_vec_from_hex("00", &mut a);

--- a/fuzz/fuzz_targets/decode_program.rs
+++ b/fuzz/fuzz_targets/decode_program.rs
@@ -16,13 +16,13 @@ extern crate simplicity;
 
 use simplicity::bititer::BitIter;
 use simplicity::bitwriter::BitWriter;
-use simplicity::core::{RedeemNode, Value};
+use simplicity::core::RedeemNode;
 use simplicity::jet::application::Core;
 
 fn do_test(data: &[u8]) {
     let mut iter = BitIter::new(data.iter().cloned());
 
-    if let Ok(program) = RedeemNode::<Value, Core>::decode(&mut iter) {
+    if let Ok(program) = RedeemNode::<Core>::decode(&mut iter) {
         let bit_len = iter.n_total_read();
 
         let mut sink = Vec::<u8>::new();

--- a/fuzz/fuzz_targets/decode_program.rs
+++ b/fuzz/fuzz_targets/decode_program.rs
@@ -16,13 +16,13 @@ extern crate simplicity;
 
 use simplicity::bititer::BitIter;
 use simplicity::bitwriter::BitWriter;
-use simplicity::core::{Node, Value};
+use simplicity::core::{RedeemNode, Value};
 use simplicity::jet::application::Core;
 
 fn do_test(data: &[u8]) {
     let mut iter = BitIter::new(data.iter().cloned());
 
-    if let Ok(program) = Node::<Value, Core>::decode(&mut iter) {
+    if let Ok(program) = RedeemNode::<Value, Core>::decode(&mut iter) {
         let bit_len = iter.n_total_read();
 
         let mut sink = Vec::<u8>::new();
@@ -31,7 +31,7 @@ fn do_test(data: &[u8]) {
         w.flush_all().expect("flushing");
         assert_eq!(w.n_total_written(), bit_len);
 
-        // Node::<Value, Core>::decode() may stop reading `data` mid-byte:
+        // RedeemNode::<Value, Core>::decode() may stop reading `data` mid-byte:
         // copy trailing bits from `data` to `sink`
         if bit_len % 8 != 0 {
             let mask = !(1u8 << (8 - (bit_len % 8)));

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -13,9 +13,9 @@
 //
 
 use crate::core::commit::CommitNodeInner;
-use crate::core::node::{NodeBounds, NodeType};
+use crate::core::redeem::{NodeBounds, NodeType};
 use crate::core::Value;
-use crate::core::{CommitNode, Node};
+use crate::core::{CommitNode, RedeemNode};
 use crate::jet::Application;
 use std::cmp;
 use std::rc::Rc;
@@ -27,8 +27,8 @@ use std::rc::Rc;
 /// Witness nodes require their node type.
 pub(crate) fn compute_bounds<Witness, App: Application>(
     untyped_node: &CommitNode<Witness, App>,
-    left: Option<Rc<Node<Value, App>>>,
-    right: Option<Rc<Node<Value, App>>>,
+    left: Option<Rc<RedeemNode<Value, App>>>,
+    right: Option<Rc<RedeemNode<Value, App>>>,
     ty: &NodeType,
 ) -> NodeBounds {
     NodeBounds {
@@ -41,8 +41,8 @@ pub(crate) fn compute_bounds<Witness, App: Application>(
 /// by the given node during execution on the Bit Machine.
 fn compute_extra_cells_bound<Witness, App: Application>(
     untyped_node: &CommitNode<Witness, App>,
-    left: Option<Rc<Node<Value, App>>>,
-    right: Option<Rc<Node<Value, App>>>,
+    left: Option<Rc<RedeemNode<Value, App>>>,
+    right: Option<Rc<RedeemNode<Value, App>>>,
     ty: &NodeType,
 ) -> usize {
     match untyped_node.inner {
@@ -81,8 +81,8 @@ fn compute_extra_cells_bound<Witness, App: Application>(
 /// by the given node during execution on the Bit Machine.
 fn compute_frame_count_bound<Witness, App: Application>(
     untyped_node: &CommitNode<Witness, App>,
-    left: Option<Rc<Node<Value, App>>>,
-    right: Option<Rc<Node<Value, App>>>,
+    left: Option<Rc<RedeemNode<Value, App>>>,
+    right: Option<Rc<RedeemNode<Value, App>>>,
 ) -> usize {
     match untyped_node.inner {
         CommitNodeInner::Iden

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -14,7 +14,6 @@
 
 use crate::core::commit::CommitNodeInner;
 use crate::core::redeem::{NodeBounds, NodeType};
-use crate::core::Value;
 use crate::core::{CommitNode, RedeemNode};
 use crate::jet::Application;
 use std::cmp;
@@ -25,10 +24,10 @@ use std::rc::Rc;
 /// Nodes with left children require their finalized left child,
 /// while nodes with right children require their finalized right child.
 /// Witness nodes require their node type.
-pub(crate) fn compute_bounds<Witness, App: Application>(
-    untyped_node: &CommitNode<Witness, App>,
-    left: Option<Rc<RedeemNode<Value, App>>>,
-    right: Option<Rc<RedeemNode<Value, App>>>,
+pub(crate) fn compute_bounds<App: Application>(
+    untyped_node: &CommitNode<App>,
+    left: Option<Rc<RedeemNode<App>>>,
+    right: Option<Rc<RedeemNode<App>>>,
     ty: &NodeType,
 ) -> NodeBounds {
     NodeBounds {
@@ -39,10 +38,10 @@ pub(crate) fn compute_bounds<Witness, App: Application>(
 
 /// Return an upper bound on the number of cells required
 /// by the given node during execution on the Bit Machine.
-fn compute_extra_cells_bound<Witness, App: Application>(
-    untyped_node: &CommitNode<Witness, App>,
-    left: Option<Rc<RedeemNode<Value, App>>>,
-    right: Option<Rc<RedeemNode<Value, App>>>,
+fn compute_extra_cells_bound<App: Application>(
+    untyped_node: &CommitNode<App>,
+    left: Option<Rc<RedeemNode<App>>>,
+    right: Option<Rc<RedeemNode<App>>>,
     ty: &NodeType,
 ) -> usize {
     match untyped_node.inner {
@@ -73,21 +72,21 @@ fn compute_extra_cells_bound<Witness, App: Application>(
                 + left.ty.target.bit_width
                 + cmp::max(left.bounds.extra_cells, right.unwrap().bounds.extra_cells)
         }
-        CommitNodeInner::Witness(_) => ty.target.bit_width,
+        CommitNodeInner::Witness => ty.target.bit_width,
     }
 }
 
 /// Return an upper bound on the number of frames required
 /// by the given node during execution on the Bit Machine.
-fn compute_frame_count_bound<Witness, App: Application>(
-    untyped_node: &CommitNode<Witness, App>,
-    left: Option<Rc<RedeemNode<Value, App>>>,
-    right: Option<Rc<RedeemNode<Value, App>>>,
+fn compute_frame_count_bound<App: Application>(
+    untyped_node: &CommitNode<App>,
+    left: Option<Rc<RedeemNode<App>>>,
+    right: Option<Rc<RedeemNode<App>>>,
 ) -> usize {
     match untyped_node.inner {
         CommitNodeInner::Iden
         | CommitNodeInner::Unit
-        | CommitNodeInner::Witness(_)
+        | CommitNodeInner::Witness
         | CommitNodeInner::Fail(_, _)
         | CommitNodeInner::Hidden(_)
         | CommitNodeInner::Jet(_) => 0,

--- a/src/bit_machine/exec.rs
+++ b/src/bit_machine/exec.rs
@@ -19,9 +19,9 @@
 //!
 
 use super::frame::Frame;
-use crate::core::node::NodeInner;
+use crate::core::redeem::RedeemNodeInner;
 use crate::core::types::TypeInner;
-use crate::core::{Node, Value};
+use crate::core::{RedeemNode, Value};
 use crate::decode;
 use crate::jet::{AppError, Application};
 use std::fmt;
@@ -42,7 +42,7 @@ pub struct BitMachine {
 
 impl BitMachine {
     /// Construct a Bit Machine with enough space to execute the given program.
-    pub fn for_program<App: Application>(program: &Node<Value, App>) -> Self {
+    pub fn for_program<App: Application>(program: &RedeemNode<Value, App>) -> Self {
         let io_width = program.ty.source.bit_width + program.ty.target.bit_width;
 
         Self {
@@ -270,12 +270,12 @@ impl BitMachine {
     /// Make sure the Bit Machine has enough space by constructing it via [`Self::for_program()`].
     pub fn exec<'a, App: Application + std::fmt::Debug>(
         &mut self,
-        program: &'a Node<Value, App>,
+        program: &'a RedeemNode<Value, App>,
         env: &App::Environment,
     ) -> Result<Value, ExecutionError<'a>> {
         // Rust cannot use `App` from parent function
         enum CallStack<'a, App: Application> {
-            Goto(&'a Node<Value, App>),
+            Goto(&'a RedeemNode<Value, App>),
             MoveFrame,
             DropFrame,
             CopyFwd(usize),
@@ -303,12 +303,12 @@ impl BitMachine {
             }
 
             match &ip.inner {
-                NodeInner::Unit => {}
-                NodeInner::Iden => {
+                RedeemNodeInner::Unit => {}
+                RedeemNodeInner::Iden => {
                     let size_a = ip.ty.source.bit_width;
                     self.copy(size_a);
                 }
-                NodeInner::InjL(left) => {
+                RedeemNodeInner::InjL(left) => {
                     let padl_b_c = if let TypeInner::Sum(b, _) = &ip.ty.target.inner {
                         ip.ty.target.bit_width - b.bit_width - 1
                     } else {
@@ -319,7 +319,7 @@ impl BitMachine {
                     self.skip(padl_b_c);
                     call_stack.push(CallStack::Goto(left));
                 }
-                NodeInner::InjR(left) => {
+                RedeemNodeInner::InjR(left) => {
                     let padr_b_c = if let TypeInner::Sum(_, c) = &ip.ty.target.inner {
                         ip.ty.target.bit_width - c.bit_width - 1
                     } else {
@@ -330,11 +330,11 @@ impl BitMachine {
                     self.skip(padr_b_c);
                     call_stack.push(CallStack::Goto(left));
                 }
-                NodeInner::Pair(left, right) => {
+                RedeemNodeInner::Pair(left, right) => {
                     call_stack.push(CallStack::Goto(right));
                     call_stack.push(CallStack::Goto(left));
                 }
-                NodeInner::Comp(left, right) => {
+                RedeemNodeInner::Comp(left, right) => {
                     let size_b = left.ty.target.bit_width;
 
                     self.new_frame(size_b);
@@ -343,7 +343,7 @@ impl BitMachine {
                     call_stack.push(CallStack::MoveFrame);
                     call_stack.push(CallStack::Goto(left));
                 }
-                NodeInner::Disconnect(left, right) => {
+                RedeemNodeInner::Disconnect(left, right) => {
                     let size_prod_256_a = left.ty.source.bit_width;
                     let size_a = size_prod_256_a - 256;
                     let size_prod_b_c = left.ty.target.bit_width;
@@ -363,8 +363,8 @@ impl BitMachine {
                     call_stack.push(CallStack::MoveFrame);
                     call_stack.push(CallStack::Goto(left));
                 }
-                NodeInner::Take(left) => call_stack.push(CallStack::Goto(left)),
-                NodeInner::Drop(left) => {
+                RedeemNodeInner::Take(left) => call_stack.push(CallStack::Goto(left)),
+                RedeemNodeInner::Drop(left) => {
                     let size_a = if let TypeInner::Product(a, _) = &ip.ty.source.inner {
                         a.bit_width
                     } else {
@@ -375,9 +375,9 @@ impl BitMachine {
                     call_stack.push(CallStack::Back(size_a));
                     call_stack.push(CallStack::Goto(left));
                 }
-                NodeInner::Case(left, right)
-                | NodeInner::AssertL(left, right)
-                | NodeInner::AssertR(left, right) => {
+                RedeemNodeInner::Case(left, right)
+                | RedeemNodeInner::AssertL(left, right)
+                | RedeemNodeInner::AssertR(left, right) => {
                     let choice_bit = self.read[self.read.len() - 1].peek_bit(&self.data);
 
                     let (size_a, size_b) =
@@ -403,17 +403,17 @@ impl BitMachine {
                         call_stack.push(CallStack::Goto(left));
                     }
                 }
-                NodeInner::Witness(value) => self.write_value(value),
-                NodeInner::Hidden(h) => {
+                RedeemNodeInner::Witness(value) => self.write_value(value),
+                RedeemNodeInner::Hidden(h) => {
                     // TODO: Convert into crate::Error
                     panic!(
                         "Hit hidden node {:?} at iteration {}: {}",
                         ip, iterations, h
                     )
                 }
-                NodeInner::Jet(j) => App::exec_jet(j, self, env)
+                RedeemNodeInner::Jet(j) => App::exec_jet(j, self, env)
                     .map_err(|x| ExecutionError::AppError(Box::new(x)))?,
-                NodeInner::Fail(..) => return Err(ExecutionError::ReachedFailNode),
+                RedeemNodeInner::Fail(..) => return Err(ExecutionError::ReachedFailNode),
             }
 
             ip = loop {

--- a/src/bit_machine/exec.rs
+++ b/src/bit_machine/exec.rs
@@ -42,7 +42,7 @@ pub struct BitMachine {
 
 impl BitMachine {
     /// Construct a Bit Machine with enough space to execute the given program.
-    pub fn for_program<App: Application>(program: &RedeemNode<Value, App>) -> Self {
+    pub fn for_program<App: Application>(program: &RedeemNode<App>) -> Self {
         let io_width = program.ty.source.bit_width + program.ty.target.bit_width;
 
         Self {
@@ -270,12 +270,12 @@ impl BitMachine {
     /// Make sure the Bit Machine has enough space by constructing it via [`Self::for_program()`].
     pub fn exec<'a, App: Application + std::fmt::Debug>(
         &mut self,
-        program: &'a RedeemNode<Value, App>,
+        program: &'a RedeemNode<App>,
         env: &App::Environment,
     ) -> Result<Value, ExecutionError<'a>> {
         // Rust cannot use `App` from parent function
         enum CallStack<'a, App: Application> {
-            Goto(&'a RedeemNode<Value, App>),
+            Goto(&'a RedeemNode<App>),
             MoveFrame,
             DropFrame,
             CopyFwd(usize),

--- a/src/core/commit.rs
+++ b/src/core/commit.rs
@@ -16,8 +16,8 @@
 use crate::bititer::BitIter;
 use crate::bitwriter::BitWriter;
 use crate::core::iter::{DagIterable, WitnessIterator};
-use crate::core::node::NodeInner;
-use crate::core::{Node, Value};
+use crate::core::redeem::RedeemNodeInner;
+use crate::core::{RedeemNode, Value};
 use crate::jet::{Application, JetNode};
 use crate::merkle::cmr::Cmr;
 use crate::merkle::{cmr, imr};
@@ -392,11 +392,11 @@ impl<Witness, App: Application> CommitNode<Witness, App> {
     pub fn finalize<W: WitnessIterator>(
         &self,
         mut witness: W,
-    ) -> Result<Rc<Node<Value, App>>, Error> {
+    ) -> Result<Rc<RedeemNode<Value, App>>, Error> {
         let root = RefWrapper(self);
         let post_order_it = root.iter_post_order();
         let arrows = inference::get_arrows(post_order_it.clone())?;
-        let mut to_finalized: HashMap<RefWrapper<Witness, App>, Rc<Node<Value, App>>> =
+        let mut to_finalized: HashMap<RefWrapper<Witness, App>, Rc<RedeemNode<Value, App>>> =
             HashMap::new();
 
         for commit in post_order_it {
@@ -430,26 +430,30 @@ impl<Witness, App: Application> CommitNode<Witness, App> {
 
             // Verbose but necessary thanks to Rust
             let inner = match commit.0.inner {
-                CommitNodeInner::Iden => NodeInner::Iden,
-                CommitNodeInner::Unit => NodeInner::Unit,
-                CommitNodeInner::InjL(_) => NodeInner::InjL(left.unwrap()),
-                CommitNodeInner::InjR(_) => NodeInner::InjR(left.unwrap()),
-                CommitNodeInner::Take(_) => NodeInner::Take(left.unwrap()),
-                CommitNodeInner::Drop(_) => NodeInner::Drop(left.unwrap()),
-                CommitNodeInner::Comp(_, _) => NodeInner::Comp(left.unwrap(), right.unwrap()),
-                CommitNodeInner::Case(_, _) => NodeInner::Case(left.unwrap(), right.unwrap()),
-                CommitNodeInner::AssertL(_, _) => NodeInner::AssertL(left.unwrap(), right.unwrap()),
-                CommitNodeInner::AssertR(_, _) => NodeInner::AssertR(left.unwrap(), right.unwrap()),
-                CommitNodeInner::Pair(_, _) => NodeInner::Pair(left.unwrap(), right.unwrap()),
-                CommitNodeInner::Disconnect(_, _) => {
-                    NodeInner::Disconnect(left.unwrap(), right.unwrap())
+                CommitNodeInner::Iden => RedeemNodeInner::Iden,
+                CommitNodeInner::Unit => RedeemNodeInner::Unit,
+                CommitNodeInner::InjL(_) => RedeemNodeInner::InjL(left.unwrap()),
+                CommitNodeInner::InjR(_) => RedeemNodeInner::InjR(left.unwrap()),
+                CommitNodeInner::Take(_) => RedeemNodeInner::Take(left.unwrap()),
+                CommitNodeInner::Drop(_) => RedeemNodeInner::Drop(left.unwrap()),
+                CommitNodeInner::Comp(_, _) => RedeemNodeInner::Comp(left.unwrap(), right.unwrap()),
+                CommitNodeInner::Case(_, _) => RedeemNodeInner::Case(left.unwrap(), right.unwrap()),
+                CommitNodeInner::AssertL(_, _) => {
+                    RedeemNodeInner::AssertL(left.unwrap(), right.unwrap())
                 }
-                CommitNodeInner::Witness(_) => NodeInner::Witness(value.unwrap()),
-                CommitNodeInner::Fail(hl, hr) => NodeInner::Fail(hl, hr),
-                CommitNodeInner::Hidden(h) => NodeInner::Hidden(h),
-                CommitNodeInner::Jet(jet) => NodeInner::Jet(jet),
+                CommitNodeInner::AssertR(_, _) => {
+                    RedeemNodeInner::AssertR(left.unwrap(), right.unwrap())
+                }
+                CommitNodeInner::Pair(_, _) => RedeemNodeInner::Pair(left.unwrap(), right.unwrap()),
+                CommitNodeInner::Disconnect(_, _) => {
+                    RedeemNodeInner::Disconnect(left.unwrap(), right.unwrap())
+                }
+                CommitNodeInner::Witness(_) => RedeemNodeInner::Witness(value.unwrap()),
+                CommitNodeInner::Fail(hl, hr) => RedeemNodeInner::Fail(hl, hr),
+                CommitNodeInner::Hidden(h) => RedeemNodeInner::Hidden(h),
+                CommitNodeInner::Jet(jet) => RedeemNodeInner::Jet(jet),
             };
-            let node = Node {
+            let node = RedeemNode {
                 inner,
                 cmr: commit.0.cmr,
                 imr,

--- a/src/core/commit.rs
+++ b/src/core/commit.rs
@@ -470,7 +470,7 @@ impl<App: Application> CommitNode<App> {
     /// This means, the program simply has no witness during commitment,
     /// or the witness is provided by other means.
     ///
-    /// If the serialization contains the witness data, then use [`Node::decode()`].
+    /// If the serialization contains the witness data, then use [`RedeemNode::decode()`].
     pub fn decode<I: Iterator<Item = u8>>(bits: &mut BitIter<I>) -> Result<Rc<Self>, Error> {
         decode::decode_program_fresh_witness(bits)
     }
@@ -480,7 +480,7 @@ impl<App: Application> CommitNode<App> {
     /// # Usage
     ///
     /// Use this method only if the program has no witness data.
-    /// Otherwise, add the witness via [`Self::finalize()`] and use [`Node::encode()`].
+    /// Otherwise, add the witness via [`Self::finalize()`] and use [`RedeemNode::encode()`].
     pub fn encode<W: io::Write>(&self, w: &mut BitWriter<W>) -> io::Result<usize> {
         let empty_witness = std::iter::repeat(Value::Unit);
         let program = self.finalize(empty_witness).expect("finalize");

--- a/src/core/commit.rs
+++ b/src/core/commit.rs
@@ -499,6 +499,7 @@ impl<App: Application> fmt::Display for CommitNode<App> {
 }
 
 /// Wrapper of references to [`CommitNode`].
+/// Zero-cost implementation of `Copy`, `Eq` and `Hash` via pointer equality.
 #[derive(Debug)]
 pub struct RefWrapper<'a, App: Application>(pub &'a CommitNode<App>);
 

--- a/src/core/iter.rs
+++ b/src/core/iter.rs
@@ -14,7 +14,7 @@
 
 //! Iterators over DAGs
 
-use crate::core::node::{NodeInner, RefWrapper};
+use crate::core::redeem::{RedeemNodeInner, RefWrapper};
 use crate::core::types::Type;
 use crate::core::Value;
 use crate::jet::Application;
@@ -195,7 +195,7 @@ where
     I: Iterator<Item = RefWrapper<'a, Witness, App>> + Clone,
 {
     iter.filter_map(|node| {
-        if let NodeInner::Witness(value) = &node.0.inner {
+        if let RedeemNodeInner::Witness(value) = &node.0.inner {
             Some(value)
         } else {
             None

--- a/src/core/iter.rs
+++ b/src/core/iter.rs
@@ -138,38 +138,36 @@ impl<D: DagIterable> Iterator for PostOrderIter<D> {
 }
 
 /// Convenience macro for wrappers of references to structures over
-/// `<Witness, App: Application>`.
+/// `<App: Application>`.
 ///
 /// Implements `Clone`, `Copy`, `Eq` and `Hash` using pointers.
 /// Implements [`DagIterable`] using `self.0.get_left()` and `self.0.get_right()`.
 #[macro_export]
 macro_rules! impl_ref_wrapper {
     ($wrapper:ident) => {
-        impl<'a, Witness, App: Application> Clone for $wrapper<'a, Witness, App> {
+        impl<'a, App: Application> Clone for $wrapper<'a, App> {
             fn clone(&self) -> Self {
                 $wrapper(&(self.0).clone())
             }
         }
 
-        impl<'a, Witness, App: Application> Copy for $wrapper<'a, Witness, App> {}
+        impl<'a, App: Application> Copy for $wrapper<'a, App> {}
 
-        impl<'a, Witness, App: Application> PartialEq for $wrapper<'a, Witness, App> {
+        impl<'a, App: Application> PartialEq for $wrapper<'a, App> {
             fn eq(&self, other: &Self) -> bool {
                 std::ptr::eq(self.0, other.0)
             }
         }
 
-        impl<'a, Witness, App: Application> Eq for $wrapper<'a, Witness, App> {}
+        impl<'a, App: Application> Eq for $wrapper<'a, App> {}
 
-        impl<'a, Witness, App: Application> std::hash::Hash for $wrapper<'a, Witness, App> {
+        impl<'a, App: Application> std::hash::Hash for $wrapper<'a, App> {
             fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
                 std::ptr::hash(self.0, state)
             }
         }
 
-        impl<'a, Witness, App: Application> $crate::core::iter::DagIterable
-            for $wrapper<'a, Witness, App>
-        {
+        impl<'a, App: Application> $crate::core::iter::DagIterable for $wrapper<'a, App> {
             fn root(self) -> Option<Self> {
                 Some(self)
             }
@@ -187,12 +185,9 @@ macro_rules! impl_ref_wrapper {
 
 /// Convert the given iterator over [`RefWrapper`]s
 /// into an iterator over the contained `Witness` values.
-pub fn into_witness<'a, Witness, App: Application, I>(
-    iter: I,
-) -> impl Iterator<Item = &'a Witness> + Clone
+pub fn into_witness<'a, App: Application, I>(iter: I) -> impl Iterator<Item = &'a Value> + Clone
 where
-    Witness: 'a,
-    I: Iterator<Item = RefWrapper<'a, Witness, App>> + Clone,
+    I: Iterator<Item = RefWrapper<'a, App>> + Clone,
 {
     iter.filter_map(|node| {
         if let RedeemNodeInner::Witness(value) = &node.0.inner {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -19,10 +19,10 @@
 
 pub mod commit;
 pub mod iter;
-pub mod node;
+pub mod redeem;
 pub mod types;
 mod value;
 
 pub use commit::CommitNode;
-pub use node::Node;
+pub use redeem::RedeemNode;
 pub use value::Value;

--- a/src/core/redeem.rs
+++ b/src/core/redeem.rs
@@ -31,33 +31,33 @@ use std::{fmt, io};
 /// # See
 /// [`crate::core::commit::CommitNodeInner`]
 #[derive(Debug)]
-pub enum RedeemNodeInner<Witness, App: Application> {
+pub enum RedeemNodeInner<App: Application> {
     /// Identity
     Iden,
     /// Unit constant
     Unit,
     /// Left injection of some child
-    InjL(Rc<RedeemNode<Witness, App>>),
+    InjL(Rc<RedeemNode<App>>),
     /// Right injection of some child
-    InjR(Rc<RedeemNode<Witness, App>>),
+    InjR(Rc<RedeemNode<App>>),
     /// Take of some child
-    Take(Rc<RedeemNode<Witness, App>>),
+    Take(Rc<RedeemNode<App>>),
     /// Drop of some child
-    Drop(Rc<RedeemNode<Witness, App>>),
+    Drop(Rc<RedeemNode<App>>),
     /// Composition of a left and right child
-    Comp(Rc<RedeemNode<Witness, App>>, Rc<RedeemNode<Witness, App>>),
+    Comp(Rc<RedeemNode<App>>, Rc<RedeemNode<App>>),
     /// Case of a left and right child
-    Case(Rc<RedeemNode<Witness, App>>, Rc<RedeemNode<Witness, App>>),
+    Case(Rc<RedeemNode<App>>, Rc<RedeemNode<App>>),
     /// Left assertion of a left and right child.
-    AssertL(Rc<RedeemNode<Witness, App>>, Rc<RedeemNode<Witness, App>>),
+    AssertL(Rc<RedeemNode<App>>, Rc<RedeemNode<App>>),
     /// Right assertion of a left and right child.
-    AssertR(Rc<RedeemNode<Witness, App>>, Rc<RedeemNode<Witness, App>>),
+    AssertR(Rc<RedeemNode<App>>, Rc<RedeemNode<App>>),
     /// Pair of a left and right child
-    Pair(Rc<RedeemNode<Witness, App>>, Rc<RedeemNode<Witness, App>>),
+    Pair(Rc<RedeemNode<App>>, Rc<RedeemNode<App>>),
     /// Disconnect of a left and right child
-    Disconnect(Rc<RedeemNode<Witness, App>>, Rc<RedeemNode<Witness, App>>),
+    Disconnect(Rc<RedeemNode<App>>, Rc<RedeemNode<App>>),
     /// Witness data
-    Witness(Witness),
+    Witness(Value),
     /// Universal fail
     Fail(Cmr, Cmr),
     /// Hidden CMR
@@ -66,7 +66,7 @@ pub enum RedeemNodeInner<Witness, App: Application> {
     Jet(&'static JetNode<App>),
 }
 
-impl<Witness: fmt::Display, App: Application> fmt::Display for RedeemNodeInner<Witness, App> {
+impl<App: Application> fmt::Display for RedeemNodeInner<App> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             RedeemNodeInner::Iden => f.write_str("iden"),
@@ -119,9 +119,9 @@ pub struct NodeBounds {
 /// # See
 /// [`crate::core::CommitNode`]
 #[derive(Debug)]
-pub struct RedeemNode<Witness, App: Application> {
+pub struct RedeemNode<App: Application> {
     /// Underlying combinator of the node
-    pub inner: RedeemNodeInner<Witness, App>,
+    pub inner: RedeemNodeInner<App>,
     /// Commitment Merkle root of the node
     pub cmr: Cmr,
     /// Identity Merkle root of the node
@@ -132,7 +132,7 @@ pub struct RedeemNode<Witness, App: Application> {
     pub bounds: NodeBounds,
 }
 
-impl<Witness, App: Application> RedeemNode<Witness, App> {
+impl<App: Application> RedeemNode<App> {
     /// Return the left child of the node, if there is such a child.
     pub fn get_left(&self) -> Option<&Self> {
         match &self.inner {
@@ -187,9 +187,7 @@ impl<Witness, App: Application> RedeemNode<Witness, App> {
             }
         })
     }
-}
 
-impl<App: Application> RedeemNode<Value, App> {
     /// Decode a Simplicity program from bits, including the witness data.
     pub fn decode<I: Iterator<Item = u8>>(bits: &mut BitIter<I>) -> Result<Rc<Self>, Error> {
         let commit = decode::decode_program_exact_witness(bits)?;
@@ -212,7 +210,7 @@ impl<App: Application> RedeemNode<Value, App> {
     }
 }
 
-impl<Witness: fmt::Display, App: Application> fmt::Display for RedeemNode<Witness, App> {
+impl<App: Application> fmt::Display for RedeemNode<App> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         RefWrapper(self).display(
             f,
@@ -224,6 +222,6 @@ impl<Witness: fmt::Display, App: Application> fmt::Display for RedeemNode<Witnes
 
 /// Wrapper of references to [`Node`].
 #[derive(Debug)]
-pub struct RefWrapper<'a, Witness, App: Application>(pub &'a RedeemNode<Witness, App>);
+pub struct RefWrapper<'a, App: Application>(pub &'a RedeemNode<App>);
 
 impl_ref_wrapper!(RefWrapper);

--- a/src/core/redeem.rs
+++ b/src/core/redeem.rs
@@ -220,7 +220,8 @@ impl<App: Application> fmt::Display for RedeemNode<App> {
     }
 }
 
-/// Wrapper of references to [`Node`].
+/// Wrapper of references to [`RedeemNode`].
+/// Zero-cost implementation of `Copy`, `Eq` and `Hash` via pointer equality.
 #[derive(Debug)]
 pub struct RefWrapper<'a, App: Application>(pub &'a RedeemNode<App>);
 

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -21,7 +21,7 @@
 
 use crate::bitwriter::BitWriter;
 use crate::core::iter::{DagIterable, PostOrderIter};
-use crate::core::node::{NodeInner, RefWrapper};
+use crate::core::redeem::{RedeemNodeInner, RefWrapper};
 use crate::core::Value;
 use crate::jet::Application;
 use crate::sharing;
@@ -71,16 +71,18 @@ fn encode_node<W: io::Write, Witness, App: Application>(
             let j = index - j_abs;
 
             match &node.0.inner {
-                NodeInner::Comp(_, _) => {
+                RedeemNodeInner::Comp(_, _) => {
                     w.write_bits_be(0, 5)?;
                 }
-                NodeInner::Case(_, _) | NodeInner::AssertL(_, _) | NodeInner::AssertR(_, _) => {
+                RedeemNodeInner::Case(_, _)
+                | RedeemNodeInner::AssertL(_, _)
+                | RedeemNodeInner::AssertR(_, _) => {
                     w.write_bits_be(1, 5)?;
                 }
-                NodeInner::Pair(_, _) => {
+                RedeemNodeInner::Pair(_, _) => {
                     w.write_bits_be(2, 5)?;
                 }
-                NodeInner::Disconnect(_, _) => {
+                RedeemNodeInner::Disconnect(_, _) => {
                     w.write_bits_be(3, 5)?;
                 }
                 _ => unreachable!(),
@@ -90,16 +92,16 @@ fn encode_node<W: io::Write, Witness, App: Application>(
             encode_natural(j, w)?;
         } else {
             match &node.0.inner {
-                NodeInner::InjL(_) => {
+                RedeemNodeInner::InjL(_) => {
                     w.write_bits_be(4, 5)?;
                 }
-                NodeInner::InjR(_) => {
+                RedeemNodeInner::InjR(_) => {
                     w.write_bits_be(5, 5)?;
                 }
-                NodeInner::Take(_) => {
+                RedeemNodeInner::Take(_) => {
                     w.write_bits_be(6, 5)?;
                 }
-                NodeInner::Drop(_) => {
+                RedeemNodeInner::Drop(_) => {
                     w.write_bits_be(7, 5)?;
                 }
                 _ => unreachable!(),
@@ -109,25 +111,25 @@ fn encode_node<W: io::Write, Witness, App: Application>(
         }
     } else {
         match &node.0.inner {
-            NodeInner::Iden => {
+            RedeemNodeInner::Iden => {
                 w.write_bits_be(8, 5)?;
             }
-            NodeInner::Unit => {
+            RedeemNodeInner::Unit => {
                 w.write_bits_be(9, 5)?;
             }
-            NodeInner::Fail(hl, hr) => {
+            RedeemNodeInner::Fail(hl, hr) => {
                 w.write_bits_be(10, 5)?;
                 encode_hash(hl.as_ref(), w)?;
                 encode_hash(hr.as_ref(), w)?;
             }
-            NodeInner::Hidden(h) => {
+            RedeemNodeInner::Hidden(h) => {
                 w.write_bits_be(6, 4)?;
                 encode_hash(h.as_ref(), w)?;
             }
-            NodeInner::Witness(_) => {
+            RedeemNodeInner::Witness(_) => {
                 w.write_bits_be(7, 4)?;
             }
-            NodeInner::Jet(jet) => {
+            RedeemNodeInner::Jet(jet) => {
                 App::encode_jet(jet, w)?;
             }
             _ => unreachable!(),

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -31,8 +31,8 @@ use std::{io, mem};
 /// Encode a Simplicity program to bits, without witness data.
 ///
 /// Returns the number of written bits.
-pub fn encode_program<W: io::Write, Witness, App: Application>(
-    program: PostOrderIter<RefWrapper<Witness, App>>,
+pub fn encode_program<W: io::Write, App: Application>(
+    program: PostOrderIter<RefWrapper<App>>,
     w: &mut BitWriter<W>,
 ) -> io::Result<usize> {
     let (node_to_index, len) = sharing::compute_maximal_sharing(program.clone());
@@ -54,10 +54,10 @@ pub fn encode_program<W: io::Write, Witness, App: Application>(
 }
 
 /// Encode a node to bits.
-fn encode_node<W: io::Write, Witness, App: Application>(
-    node: RefWrapper<Witness, App>,
+fn encode_node<W: io::Write, App: Application>(
+    node: RefWrapper<App>,
     index: usize,
-    node_to_index: &HashMap<RefWrapper<Witness, App>, usize>,
+    node_to_index: &HashMap<RefWrapper<App>, usize>,
     w: &mut BitWriter<W>,
 ) -> io::Result<()> {
     if let Some(left) = node.get_left() {

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -138,14 +138,14 @@ struct UnificationArrow {
 // TODO: Remove once local type checking is implemented
 /// Storage of the unification arrows for each node of a Simplicity DAG.
 #[derive(Debug)]
-pub(crate) struct Arrows<'a, Witness, App: Application> {
-    node_to_arrow: HashMap<RefWrapper<'a, Witness, App>, UnificationArrow>,
+pub(crate) struct Arrows<'a, App: Application> {
+    node_to_arrow: HashMap<RefWrapper<'a, App>, UnificationArrow>,
 }
 
-impl<'a, Witness, App: Application> Arrows<'a, Witness, App> {
+impl<'a, App: Application> Arrows<'a, App> {
     /// Return the finalized type of the given node.
     /// To work, this method must be called on nodes in post order!
-    pub fn finalize(&self, node: &RefWrapper<'a, Witness, App>) -> Result<NodeType, Error> {
+    pub fn finalize(&self, node: &RefWrapper<'a, App>) -> Result<NodeType, Error> {
         let arrow = self
             .node_to_arrow
             .get(node)
@@ -167,10 +167,10 @@ impl<'a, Witness, App: Application> Arrows<'a, Witness, App> {
 }
 
 /// Return the initialized unification arrows of a Simplicity DAG.
-pub(crate) fn get_arrows<Witness, App: Application>(
-    it: PostOrderIter<RefWrapper<Witness, App>>,
-) -> Result<Arrows<Witness, App>, Error> {
-    let mut node_to_arrow: HashMap<RefWrapper<Witness, App>, UnificationArrow> = HashMap::new();
+pub(crate) fn get_arrows<App: Application>(
+    it: PostOrderIter<RefWrapper<App>>,
+) -> Result<Arrows<App>, Error> {
+    let mut node_to_arrow: HashMap<RefWrapper<App>, UnificationArrow> = HashMap::new();
     let pow2s = Variable::powers_of_two();
     let mut naming = VariableFactory::new();
 
@@ -289,7 +289,7 @@ pub(crate) fn get_arrows<Witness, App: Application>(
             match &untyped_node.0.inner {
                 CommitNodeInner::Iden => unify(arrow.source.clone(), arrow.target.clone())?,
                 CommitNodeInner::Unit => bind(&arrow.target, VariableType::Unit)?,
-                CommitNodeInner::Witness(_)
+                CommitNodeInner::Witness
                 | CommitNodeInner::Fail(_, _)
                 | CommitNodeInner::Hidden(_) => {
                     // no type constraints

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -1,6 +1,6 @@
 use crate::core::commit::{CommitNodeInner, RefWrapper};
 use crate::core::iter::{DagIterable, PostOrderIter};
-use crate::core::node::NodeType;
+use crate::core::redeem::NodeType;
 use crate::core::types::{RcVar, Type, Variable, VariableFactory, VariableInner, VariableType};
 use crate::jet::Application;
 use crate::Error;

--- a/src/jet/application/elements/tests.rs
+++ b/src/jet/application/elements/tests.rs
@@ -22,7 +22,7 @@ fn sighash_all_cmr() {
         .iter()
         .cloned()
         .into();
-    let program = RedeemNode::<_, Elements>::decode(&mut bits).expect("decoding program");
+    let program = RedeemNode::<Elements>::decode(&mut bits).expect("decoding program");
 
     assert_eq!(program.cmr.into_inner(), sighash_all::SIGHASH_ALL_CMR);
     // TODO: check IMR
@@ -134,7 +134,7 @@ fn exec_sighash_all() {
         .iter()
         .cloned()
         .into();
-    let program = RedeemNode::<_, Elements>::decode(&mut bits).expect("decoding program");
+    let program = RedeemNode::<Elements>::decode(&mut bits).expect("decoding program");
 
     let mut mac = BitMachine::for_program(&program);
     mac.exec(&program, &env).unwrap();

--- a/src/jet/application/elements/tests.rs
+++ b/src/jet/application/elements/tests.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::bititer::BitIter;
-use crate::core::Node;
+use crate::core::RedeemNode;
 use crate::exec::BitMachine;
 use crate::jet::application::elements::{ElementsEnv, ElementsUtxo};
 use crate::jet::application::Elements;
@@ -22,7 +22,7 @@ fn sighash_all_cmr() {
         .iter()
         .cloned()
         .into();
-    let program = Node::<_, Elements>::decode(&mut bits).expect("decoding program");
+    let program = RedeemNode::<_, Elements>::decode(&mut bits).expect("decoding program");
 
     assert_eq!(program.cmr.into_inner(), sighash_all::SIGHASH_ALL_CMR);
     // TODO: check IMR
@@ -134,7 +134,7 @@ fn exec_sighash_all() {
         .iter()
         .cloned()
         .into();
-    let program = Node::<_, Elements>::decode(&mut bits).expect("decoding program");
+    let program = RedeemNode::<_, Elements>::decode(&mut bits).expect("decoding program");
 
     let mut mac = BitMachine::for_program(&program);
     mac.exec(&program, &env).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ mod test_progs;
 mod util;
 
 pub use crate::bit_machine::exec;
+pub use crate::core::{CommitNode, RedeemNode};
 use std::fmt;
 
 /// Error type for simplicity

--- a/src/merkle/cmr.rs
+++ b/src/merkle/cmr.rs
@@ -30,7 +30,7 @@ pub struct Cmr(pub(crate) Midstate);
 impl_midstate_wrapper!(Cmr);
 
 impl CommitMerkleRoot for Cmr {
-    fn get_iv<Witness, App: Application>(node: &CommitNodeInner<Witness, App>) -> Self {
+    fn get_iv<App: Application>(node: &CommitNodeInner<App>) -> Self {
         match node {
             CommitNodeInner::Iden => Cmr::tag_iv(b"Simplicity-Draft\x1fCommitment\x1fiden"),
             CommitNodeInner::Unit => Cmr::tag_iv(b"Simplicity-Draft\x1fCommitment\x1funit"),
@@ -48,9 +48,7 @@ impl CommitMerkleRoot for Cmr {
             CommitNodeInner::Disconnect(_, _) => {
                 Cmr::tag_iv(b"Simplicity-Draft\x1fCommitment\x1fdisconnect")
             }
-            CommitNodeInner::Witness(_) => {
-                Cmr::tag_iv(b"Simplicity-Draft\x1fCommitment\x1fwitness")
-            }
+            CommitNodeInner::Witness => Cmr::tag_iv(b"Simplicity-Draft\x1fCommitment\x1fwitness"),
             CommitNodeInner::Fail(_, _) => Cmr::tag_iv(b"Simplicity-Draft\x1fCommitment\x1ffail"),
             CommitNodeInner::Hidden(h) => *h,
             CommitNodeInner::Jet(jet) => jet.cmr(),
@@ -59,13 +57,13 @@ impl CommitMerkleRoot for Cmr {
 }
 
 /// Compute the CMR of the given `node`.
-pub(crate) fn compute_cmr<Witness, App: Application>(node: &CommitNodeInner<Witness, App>) -> Cmr {
+pub(crate) fn compute_cmr<App: Application>(node: &CommitNodeInner<App>) -> Cmr {
     let cmr_iv = Cmr::get_iv(node);
 
     match node {
         CommitNodeInner::Iden
         | CommitNodeInner::Unit
-        | CommitNodeInner::Witness(..)
+        | CommitNodeInner::Witness
         | CommitNodeInner::Fail(..)
         | CommitNodeInner::Hidden(..)
         | CommitNodeInner::Jet(..) => cmr_iv,

--- a/src/merkle/common.rs
+++ b/src/merkle/common.rs
@@ -137,7 +137,7 @@ pub trait CommitMerkleRoot: MerkleRoot {
 pub trait TypeMerkleRoot: MerkleRoot {
     /// Return the initial value for the given type.
     ///
-    /// Each [`Type::ty`] corresponds to some tag that is hashed
+    /// Each [`Type::inner`] corresponds to some tag that is hashed
     /// and returned as initial value
     fn get_iv(ty: &TypeInner) -> Self;
 }

--- a/src/merkle/common.rs
+++ b/src/merkle/common.rs
@@ -130,7 +130,7 @@ pub trait CommitMerkleRoot: MerkleRoot {
     ///
     /// Each [`CommitNodeInner`] corresponds to some tag that is hashed
     /// and returned as initial value
-    fn get_iv<Witness, App: Application>(node: &CommitNodeInner<Witness, App>) -> Self;
+    fn get_iv<App: Application>(node: &CommitNodeInner<App>) -> Self;
 }
 
 /// Tagged SHA256 hash used for [`Type`]

--- a/src/merkle/imr.rs
+++ b/src/merkle/imr.rs
@@ -35,12 +35,12 @@ pub struct Imr(Midstate);
 impl_midstate_wrapper!(Imr);
 
 impl CommitMerkleRoot for Imr {
-    fn get_iv<Witness, App: Application>(node: &CommitNodeInner<Witness, App>) -> Self {
+    fn get_iv<App: Application>(node: &CommitNodeInner<App>) -> Self {
         match node {
             CommitNodeInner::Disconnect(_, _) => {
                 Imr::tag_iv(b"Simplicity-Draft\x1fIdentity\x1fdisconnect")
             }
-            CommitNodeInner::Witness(_) => Imr::tag_iv(b"Simplicity-Draft\x1fIdentity\x1fwitness"),
+            CommitNodeInner::Witness => Imr::tag_iv(b"Simplicity-Draft\x1fIdentity\x1fwitness"),
             _ => Cmr::get_iv(node).into_inner().into(),
         }
     }
@@ -51,10 +51,10 @@ impl CommitMerkleRoot for Imr {
 /// Nodes with left children require their finalized left child,
 /// while nodes with right children require their finalized right child.
 /// Witness nodes require their value and node type.
-pub(crate) fn compute_imr<Witness, App: Application>(
-    node: &CommitNodeInner<Witness, App>,
-    left: Option<Rc<RedeemNode<Value, App>>>,
-    right: Option<Rc<RedeemNode<Value, App>>>,
+pub(crate) fn compute_imr<App: Application>(
+    node: &CommitNodeInner<App>,
+    left: Option<Rc<RedeemNode<App>>>,
+    right: Option<Rc<RedeemNode<App>>>,
     value: Option<&Value>,
     ty: &NodeType,
 ) -> Imr {
@@ -76,6 +76,6 @@ pub(crate) fn compute_imr<Witness, App: Application>(
         | CommitNodeInner::Pair(_, _)
         | CommitNodeInner::AssertL(_, _)
         | CommitNodeInner::AssertR(_, _) => imr_iv.update(left.unwrap().imr, right.unwrap().imr),
-        CommitNodeInner::Witness(_) => imr_iv.update_value(value.unwrap(), ty.target.as_ref()),
+        CommitNodeInner::Witness => imr_iv.update_value(value.unwrap(), ty.target.as_ref()),
     }
 }

--- a/src/merkle/imr.rs
+++ b/src/merkle/imr.rs
@@ -19,8 +19,8 @@
 //! The type of `witness` data is included in the hash via [`super::tmr`].
 
 use crate::core::commit::CommitNodeInner;
-use crate::core::node::NodeType;
-use crate::core::{Node, Value};
+use crate::core::redeem::NodeType;
+use crate::core::{RedeemNode, Value};
 use crate::impl_midstate_wrapper;
 use crate::jet::Application;
 use crate::merkle::cmr::Cmr;
@@ -53,8 +53,8 @@ impl CommitMerkleRoot for Imr {
 /// Witness nodes require their value and node type.
 pub(crate) fn compute_imr<Witness, App: Application>(
     node: &CommitNodeInner<Witness, App>,
-    left: Option<Rc<Node<Value, App>>>,
-    right: Option<Rc<Node<Value, App>>>,
+    left: Option<Rc<RedeemNode<Value, App>>>,
+    right: Option<Rc<RedeemNode<Value, App>>>,
     value: Option<&Value>,
     ty: &NodeType,
 ) -> Imr {

--- a/src/policy/ast.rs
+++ b/src/policy/ast.rs
@@ -62,7 +62,7 @@ pub enum Policy<Pk: MiniscriptKey> {
 
 impl<Pk: MiniscriptKey + PublicKey32> Policy<Pk> {
     /// Compile the policy into a Simplicity program
-    pub fn compile(&self) -> Result<Rc<CommitNode<(), Bitcoin>>, Error> {
+    pub fn compile(&self) -> Result<Rc<CommitNode<Bitcoin>>, Error> {
         compiler::compile(self)
     }
 }

--- a/src/sharing.rs
+++ b/src/sharing.rs
@@ -23,8 +23,8 @@ use std::collections::{HashMap, HashSet};
 /// 1. For hidden nodes, their hash must be unique in the program.
 /// 2. For non-hidden nodes, the triple of their IMR, source type TMR and target type TMR
 ///    must be unique in the program.
-pub(crate) fn check_maximal_sharing<Witness, App: Application>(
-    program: PostOrderIter<RefWrapper<Witness, App>>,
+pub(crate) fn check_maximal_sharing<App: Application>(
+    program: PostOrderIter<RefWrapper<App>>,
 ) -> bool {
     let mut seen_hashes = HashSet::new();
     let mut seen_keys = HashSet::new();
@@ -57,9 +57,9 @@ pub(crate) fn check_maximal_sharing<Witness, App: Application>(
 ///
 /// # See
 /// [`check_maximal_sharing()`]
-pub(crate) fn compute_maximal_sharing<Witness, App: Application>(
-    program: PostOrderIter<RefWrapper<Witness, App>>,
-) -> (HashMap<RefWrapper<Witness, App>, usize>, usize) {
+pub(crate) fn compute_maximal_sharing<App: Application>(
+    program: PostOrderIter<RefWrapper<App>>,
+) -> (HashMap<RefWrapper<App>, usize>, usize) {
     let mut node_to_index = HashMap::new();
     let mut index = 0;
     let mut hash_to_node = HashMap::new();

--- a/src/sharing.rs
+++ b/src/sharing.rs
@@ -13,7 +13,7 @@
 //
 
 use crate::core::iter::PostOrderIter;
-use crate::core::node::{NodeInner, RefWrapper};
+use crate::core::redeem::{RedeemNodeInner, RefWrapper};
 use crate::jet::Application;
 use std::collections::{HashMap, HashSet};
 
@@ -30,7 +30,7 @@ pub(crate) fn check_maximal_sharing<Witness, App: Application>(
     let mut seen_keys = HashSet::new();
 
     for node in program {
-        if let NodeInner::Hidden(h) = node.0.inner {
+        if let RedeemNodeInner::Hidden(h) = node.0.inner {
             if seen_hashes.contains(&h) {
                 return false;
             } else {
@@ -68,7 +68,7 @@ pub(crate) fn compute_maximal_sharing<Witness, App: Application>(
     for node in program {
         debug_assert!(!node_to_index.contains_key(&node));
 
-        if let NodeInner::Hidden(h) = node.0.inner {
+        if let RedeemNodeInner::Hidden(h) = node.0.inner {
             if let Some(shared_node) = hash_to_node.get(&h) {
                 node_to_index.insert(node, *node_to_index.get(shared_node).unwrap());
             } else {

--- a/src/test_progs/mod.rs
+++ b/src/test_progs/mod.rs
@@ -33,13 +33,13 @@ mod tests {
     // TODO: check IMR
     fn check_merkle_roots(bytes: &[u8], cmr: [u8; 32]) {
         let mut bits = BitIter::new(bytes.iter().cloned());
-        let commit = CommitNode::<_, Core>::decode(&mut bits).expect("decoding program");
+        let commit = CommitNode::<Core>::decode(&mut bits).expect("decoding program");
         assert_eq!(commit.cmr.into_inner(), cmr);
     }
 
     fn exec_prog(bytes: &[u8]) {
         let mut bits = BitIter::new(bytes.iter().cloned());
-        let program = RedeemNode::<_, Core>::decode(&mut bits).expect("decode");
+        let program = RedeemNode::<Core>::decode(&mut bits).expect("decode");
 
         let mut mac = BitMachine::for_program(&program);
         mac.exec(&program, &()).unwrap();
@@ -55,7 +55,7 @@ mod tests {
     #[test]
     fn exec_hashblock() {
         let mut bits = BitIter::new(HASHBLOCK.iter().cloned());
-        let program = RedeemNode::<_, Core>::decode(&mut bits).expect("decoding program");
+        let program = RedeemNode::<Core>::decode(&mut bits).expect("decoding program");
 
         let state = Value::u256_from_slice(&[
             0x6a, 0x09, 0xe6, 0x67, 0xbb, 0x67, 0xae, 0x85, 0x3c, 0x6e, 0xf3, 0x72, 0xa5, 0x4f,

--- a/src/test_progs/mod.rs
+++ b/src/test_progs/mod.rs
@@ -23,7 +23,7 @@ pub(crate) mod sighash_all;
 mod tests {
     use super::hashblock::{HASHBLOCK, HASHBLOCK_CMR};
     use crate::bititer::BitIter;
-    use crate::core::{CommitNode, Node, Value};
+    use crate::core::{CommitNode, RedeemNode, Value};
     use crate::exec::BitMachine;
     use crate::jet::application::Core;
     use crate::merkle::common::MerkleRoot;
@@ -39,7 +39,7 @@ mod tests {
 
     fn exec_prog(bytes: &[u8]) {
         let mut bits = BitIter::new(bytes.iter().cloned());
-        let program = Node::<_, Core>::decode(&mut bits).expect("decode");
+        let program = RedeemNode::<_, Core>::decode(&mut bits).expect("decode");
 
         let mut mac = BitMachine::for_program(&program);
         mac.exec(&program, &()).unwrap();
@@ -55,7 +55,7 @@ mod tests {
     #[test]
     fn exec_hashblock() {
         let mut bits = BitIter::new(HASHBLOCK.iter().cloned());
-        let program = Node::<_, Core>::decode(&mut bits).expect("decoding program");
+        let program = RedeemNode::<_, Core>::decode(&mut bits).expect("decoding program");
 
         let state = Value::u256_from_slice(&[
             0x6a, 0x09, 0xe6, 0x67, 0xbb, 0x67, 0xae, 0x85, 0x3c, 0x6e, 0xf3, 0x72, 0xa5, 0x4f,


### PR DESCRIPTION
This PR is a follow-up of #35 and fixes various things that came up in the discussion. `Node` is renamed to `RedeemNode` for more clarity. The `Witness` generic is removed so that `CommitNode` contains no witness data and `RedeemNode` contains `Value`. The node types are exported at crate level. Finally, documentation is improved. 