### PR TITLE
Fix canonical order

### DIFF
--- a/src/core/iter.rs
+++ b/src/core/iter.rs
@@ -216,3 +216,42 @@ impl<I: Iterator<Item = Value>> WitnessIterator for I {
         Ok(())
     }
 }
+
+/// Sequence of nodes with (absolute) left or right indices in post-order that form a DAG.
+pub(crate) type IndexDag = Vec<(Option<usize>, Option<usize>)>;
+
+/// Wrapper for (absolute) indices into [`IndexDag`] that implements [`DagIterable`].
+#[derive(Copy, Clone)]
+pub(crate) struct IndexNode<'a>(pub usize, pub &'a IndexDag);
+
+impl<'a> PartialEq for IndexNode<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.eq(&other.0)
+    }
+}
+
+impl<'a> Eq for IndexNode<'a> {}
+
+impl<'a> std::hash::Hash for IndexNode<'a> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state)
+    }
+}
+
+impl<'a> DagIterable for IndexNode<'a> {
+    fn root(self) -> Option<Self> {
+        if self.1.is_empty() {
+            None
+        } else {
+            Some(IndexNode(self.1.len() - 1, self.1))
+        }
+    }
+
+    fn get_left(self) -> Option<Self> {
+        self.1[self.0].0.map(|i_abs| IndexNode(i_abs, self.1))
+    }
+
+    fn get_right(self) -> Option<Self> {
+        self.1[self.0].1.map(|j_abs| IndexNode(j_abs, self.1))
+    }
+}


### PR DESCRIPTION
The indices strike back: Inserting fresh witnesses breaks our algorithm for checking canonical order. We must check canonical order of the program as it is serialised (without fresh witnesses). This PR adds a light-weight DAG structure to implement this.

We failed to recognise this error because the de/encoding of `CommitNode` is not thoroughly tested. This will change once we have local type checking to check sharing of these programs and write a fuzz test.