### PR TITLE
Optimise policy

### DIFF
--- a/src/core/commit.rs
+++ b/src/core/commit.rs
@@ -80,8 +80,8 @@ impl<App: Application> fmt::Display for CommitNodeInner<App> {
             CommitNodeInner::Pair(_, _) => f.write_str("pair"),
             CommitNodeInner::Disconnect(_, _) => f.write_str("disconnect"),
             CommitNodeInner::Witness => f.write_str("witness"),
-            CommitNodeInner::Fail(hl, hr) => write!(f, "fail({}, {})", hl, hr),
-            CommitNodeInner::Hidden(h) => write!(f, "hidden({})", h),
+            CommitNodeInner::Fail(..) => f.write_str("fail"),
+            CommitNodeInner::Hidden(..) => f.write_str("hidden"),
             CommitNodeInner::Jet(jet) => write!(f, "jet({})", jet.name),
         }
     }

--- a/src/core/commit.rs
+++ b/src/core/commit.rs
@@ -302,6 +302,23 @@ impl<App: Application> CommitNode<App> {
         CommitNode::case(CommitNode::drop(right), CommitNode::drop(left))
     }
 
+    /// Create a DAG that asserts that its child returns `true`, and fails otherwise.
+    ///
+    /// _Overall type: A → 1 where child: A → 2_
+    ///
+    /// _Type inference will fail if children are not of the correct type._
+    pub fn assert(child: Rc<Self>) -> Rc<Self> {
+        let fail_zeroes_cmr = Cmr::from([
+            177, 133, 253, 158, 70, 96, 76, 160, 2, 45, 209, 68, 83, 153, 159, 186, 164, 51, 151,
+            174, 72, 121, 107, 12, 64, 35, 186, 249, 151, 31, 21, 102,
+        ]);
+
+        CommitNode::comp(
+            CommitNode::pair(child, CommitNode::unit()),
+            CommitNode::assertr(CommitNode::hidden(fail_zeroes_cmr), CommitNode::unit()),
+        )
+    }
+
     /// Create a DAG that computes Boolean _NOT_ of the `child`.
     ///
     /// _Overall type: A → 2 where child: A → 2_

--- a/src/core/redeem.rs
+++ b/src/core/redeem.rs
@@ -81,9 +81,9 @@ impl<App: Application> fmt::Display for RedeemNodeInner<App> {
             RedeemNodeInner::AssertR(_, _) => f.write_str("assertr"),
             RedeemNodeInner::Pair(_, _) => f.write_str("pair"),
             RedeemNodeInner::Disconnect(_, _) => f.write_str("disconnect"),
-            RedeemNodeInner::Witness(_) => f.write_str("witness"),
-            RedeemNodeInner::Fail(hl, hr) => write!(f, "fail({}, {})", hl, hr),
-            RedeemNodeInner::Hidden(h) => write!(f, "hidden({})", h),
+            RedeemNodeInner::Witness(..) => f.write_str("witness"),
+            RedeemNodeInner::Fail(..) => f.write_str("fail"),
+            RedeemNodeInner::Hidden(..) => f.write_str("hidden"),
             RedeemNodeInner::Jet(jet) => write!(f, "jet({})", jet.name),
         }
     }


### PR DESCRIPTION
This PR slightly reduces the size of compiled policies with trivial clauses in conjunctions (Miniscript fragment `t:X = and(X, 1)`). It also fixes the execution and printing of hidden and fail nodes, and adds `assert`.