### PR TITLE
Fix bounds

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -32,7 +32,7 @@ pub(crate) fn compute_bounds<App: Application>(
 ) -> NodeBounds {
     NodeBounds {
         extra_cells: compute_extra_cells_bound(untyped_node, left.clone(), right.clone(), ty),
-        frame_count: compute_frame_count_bound(untyped_node, left, right),
+        extra_frames: compute_extra_frames_bound(untyped_node, left, right),
     }
 }
 
@@ -78,7 +78,7 @@ fn compute_extra_cells_bound<App: Application>(
 
 /// Return an upper bound on the number of frames required
 /// by the given node during execution on the Bit Machine.
-fn compute_frame_count_bound<App: Application>(
+fn compute_extra_frames_bound<App: Application>(
     untyped_node: &CommitNode<App>,
     left: Option<Rc<RedeemNode<App>>>,
     right: Option<Rc<RedeemNode<App>>>,
@@ -93,24 +93,24 @@ fn compute_frame_count_bound<App: Application>(
         CommitNodeInner::InjL(_)
         | CommitNodeInner::InjR(_)
         | CommitNodeInner::Take(_)
-        | CommitNodeInner::Drop(_) => left.unwrap().bounds.frame_count,
+        | CommitNodeInner::Drop(_) => left.unwrap().bounds.extra_frames,
         CommitNodeInner::Comp(_, _) => {
             1 + cmp::max(
-                left.unwrap().bounds.frame_count,
-                right.unwrap().bounds.frame_count,
+                left.unwrap().bounds.extra_frames,
+                right.unwrap().bounds.extra_frames,
             )
         }
         CommitNodeInner::Case(_, _)
         | CommitNodeInner::AssertL(_, _)
         | CommitNodeInner::AssertR(_, _)
         | CommitNodeInner::Pair(_, _) => cmp::max(
-            left.unwrap().bounds.frame_count,
-            right.unwrap().bounds.frame_count,
+            left.unwrap().bounds.extra_frames,
+            right.unwrap().bounds.extra_frames,
         ),
         CommitNodeInner::Disconnect(_, _) => {
             2 + cmp::max(
-                left.unwrap().bounds.frame_count,
-                right.unwrap().bounds.frame_count,
+                left.unwrap().bounds.extra_frames,
+                right.unwrap().bounds.extra_frames,
             )
         }
     }

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -19,6 +19,9 @@ use crate::jet::Application;
 use std::cmp;
 use std::rc::Rc;
 
+/// Number of frames required for the input and output of a Simplicity expression
+pub(crate) const IO_EXTRA_FRAMES: usize = 2;
+
 /// Return the bounds for the given node, once finalized.
 ///
 /// Nodes with left children require their finalized left child,

--- a/src/bit_machine/exec.rs
+++ b/src/bit_machine/exec.rs
@@ -48,9 +48,8 @@ impl BitMachine {
         Self {
             data: vec![0; (io_width + program.bounds.extra_cells + 7) / 8],
             next_frame_start: 0,
-            // +1 for input and output frame
-            read: Vec::with_capacity(program.bounds.frame_count + 1),
-            write: Vec::with_capacity(program.bounds.frame_count + 1),
+            read: Vec::with_capacity(program.bounds.extra_frames + 2),
+            write: Vec::with_capacity(program.bounds.extra_frames + 2),
         }
     }
 

--- a/src/bit_machine/exec.rs
+++ b/src/bit_machine/exec.rs
@@ -55,8 +55,14 @@ impl BitMachine {
 
     /// Push a new frame of given size onto the write frame stack
     fn new_frame(&mut self, len: usize) {
-        // assert!(self.next_pos as usize + len < self.data.len() * 8);
-        // assert!(self.write.len() + self.read.len() < self.read.capacity());
+        debug_assert!(
+            self.next_frame_start + len <= self.data.len() * 8,
+            "Data out of bounds: number of cells"
+        );
+        debug_assert!(
+            self.write.len() + self.read.len() < self.read.capacity(),
+            "Stacks out of bounds: number of frames"
+        );
 
         self.write.push(Frame::new(self.next_frame_start, len));
         self.next_frame_start += len;

--- a/src/bit_machine/exec.rs
+++ b/src/bit_machine/exec.rs
@@ -22,8 +22,8 @@ use super::frame::Frame;
 use crate::core::redeem::RedeemNodeInner;
 use crate::core::types::TypeInner;
 use crate::core::{RedeemNode, Value};
-use crate::decode;
 use crate::jet::{AppError, Application};
+use crate::{analysis, decode};
 use std::fmt;
 use std::{cmp, error};
 
@@ -48,8 +48,8 @@ impl BitMachine {
         Self {
             data: vec![0; (io_width + program.bounds.extra_cells + 7) / 8],
             next_frame_start: 0,
-            read: Vec::with_capacity(program.bounds.extra_frames + 2),
-            write: Vec::with_capacity(program.bounds.extra_frames + 2),
+            read: Vec::with_capacity(program.bounds.extra_frames + analysis::IO_EXTRA_FRAMES),
+            write: Vec::with_capacity(program.bounds.extra_frames + analysis::IO_EXTRA_FRAMES),
         }
     }
 

--- a/src/bit_machine/exec.rs
+++ b/src/bit_machine/exec.rs
@@ -32,7 +32,7 @@ pub struct BitMachine {
     /// Space for bytes that read and write frames point to.
     /// (De)allocation happens LIFO from left to right
     pub(crate) data: Vec<u8>,
-    /// Top of data stack; index of first non-allocated byte
+    /// Top of data stack; index of first unused bit
     pub(crate) next_frame_start: usize,
     /// Read frame stack
     pub(crate) read: Vec<Frame>,

--- a/src/core/redeem.rs
+++ b/src/core/redeem.rs
@@ -156,7 +156,7 @@ pub struct NodeBounds {
     /// Upper bound on the required number of cells
     pub extra_cells: usize,
     /// Upper bound on the required number of frames
-    pub frame_count: usize,
+    pub extra_frames: usize,
 }
 
 /// Root node of a Simplicity DAG for some application.

--- a/src/core/redeem.rs
+++ b/src/core/redeem.rs
@@ -153,9 +153,11 @@ impl fmt::Display for NodeType {
 /// Bounds on the resources required by a node during execution on the Bit Machine
 #[derive(Debug)]
 pub struct NodeBounds {
-    /// Upper bound on the required number of cells
+    /// Upper bound on the required number of cells (bits).
+    /// The root additionally requires the bit width of its source and target type (input, output)
     pub extra_cells: usize,
-    /// Upper bound on the required number of frames
+    /// Upper bound on the required number of frames (sum of read and write frames).
+    /// The root additionally requires two frames (input, output)
     pub extra_frames: usize,
 }
 


### PR DESCRIPTION
Asserts that cell and frame bounds are kept, clarifies what these bounds mean, and fixes a bug in how many frames are allocated.