### PR TITLE
Turing fixes

### DIFF
--- a/src/core/commit.rs
+++ b/src/core/commit.rs
@@ -519,11 +519,11 @@ impl<J: Jet> CommitNode<J> {
     pub fn not(context: &mut Context<J>, child: Rc<Self>) -> Result<Rc<Self>, Error> {
         let unit = Self::unit(context)?;
         let pair_child_unit = Self::pair(context, child, unit)?;
-        let bit_false = Self::bit_false(context)?;
         let bit_true = Self::bit_true(context)?;
-        let cond_false_true = Self::cond(context, bit_false, bit_true)?;
+        let bit_false = Self::bit_false(context)?;
+        let case_true_false = Self::case(context, bit_true, bit_false)?;
 
-        Self::comp(context, pair_child_unit, cond_false_true)
+        Self::comp(context, pair_child_unit, case_true_false)
     }
 
     /// Create a DAG that computes Boolean _AND_ of the `left` and `right` child.
@@ -539,9 +539,10 @@ impl<J: Jet> CommitNode<J> {
         let iden = Self::iden(context)?;
         let pair_left_iden = Self::pair(context, left, iden)?;
         let bit_false = Self::bit_false(context)?;
-        let cond_right_false = Self::cond(context, right, bit_false)?;
+        let drop_right = Self::drop(context, right)?;
+        let case_false_right = Self::case(context, bit_false, drop_right)?;
 
-        Self::comp(context, pair_left_iden, cond_right_false)
+        Self::comp(context, pair_left_iden, case_false_right)
     }
 
     /// Create a DAG that computes Boolean _OR_ of the `left` and `right`.
@@ -556,10 +557,11 @@ impl<J: Jet> CommitNode<J> {
     ) -> Result<Rc<Self>, Error> {
         let iden = Self::iden(context)?;
         let pair_left_iden = Self::pair(context, left, iden)?;
+        let drop_right = Self::drop(context, right)?;
         let bit_true = Self::bit_true(context)?;
-        let cond_true_right = Self::cond(context, bit_true, right)?;
+        let case_right_true = Self::case(context, drop_right, bit_true)?;
 
-        Self::comp(context, pair_left_iden, cond_true_right)
+        Self::comp(context, pair_left_iden, case_right_true)
     }
 
     /// Return the left child of the node, if there is such a child.

--- a/src/core/commit.rs
+++ b/src/core/commit.rs
@@ -495,18 +495,15 @@ impl<J: Jet> CommitNode<J> {
     }
 
     /// Create a DAG that asserts that its child returns `true`, and fails otherwise.
+    /// The `hash` identifies the assertion and is returned upon failure.
     ///
     /// _Overall type: A → 1 where `child`: A → 2_
     ///
     /// _Type inference will fail if children are not of the correct type._
-    pub fn assert(context: &mut Context<J>, child: Rc<Self>) -> Result<Rc<Self>, Error> {
-        let fail_zeroes_cmr = Cmr::from([
-            177, 133, 253, 158, 70, 96, 76, 160, 2, 45, 209, 68, 83, 153, 159, 186, 164, 51, 151,
-            174, 72, 121, 107, 12, 64, 35, 186, 249, 151, 31, 21, 102,
-        ]);
+    pub fn assert(context: &mut Context<J>, child: Rc<Self>, hash: Cmr) -> Result<Rc<Self>, Error> {
         let unit = Self::unit(context)?;
         let pair_child_unit = Self::pair(context, child, unit)?;
-        let hidden = Self::hidden(context, fail_zeroes_cmr)?;
+        let hidden = Self::hidden(context, hash)?;
         let unit = Self::unit(context)?;
         let assertr_hidden_unit = Self::assertr(context, hidden, unit)?;
 

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -241,9 +241,9 @@ pub(crate) fn get_arrow<J: Jet>(
                         "Cannot fail",
                     )?;
                     unify(
-                        arrow.source.clone(),
+                        left_arrow.source.clone(),
                         right_arrow.source.clone(),
-                        "Cannot fail",
+                        "Pair: Left source = Right source",
                     )?;
                     bind(
                         &arrow.target,
@@ -251,7 +251,7 @@ pub(crate) fn get_arrow<J: Jet>(
                             left_arrow.target.clone(),
                             right_arrow.target.clone(),
                         ),
-                        "Pair: Left source = right source",
+                        "Cannot fail",
                     )?;
                 }
                 CommitNodeInner::Disconnect(_, _) => {
@@ -268,6 +268,8 @@ pub(crate) fn get_arrow<J: Jet>(
 
                     unify(arrow.source.clone(), a, "Cannot fail")?;
                     unify(arrow.target.clone(), prod_b_d, "Cannot fail")?;
+                    unify(right_arrow.source.clone(), c, "Cannot fail")?;
+                    unify(right_arrow.target.clone(), d, "Cannot fail")?;
 
                     unify(
                         left_arrow.source.clone(),
@@ -279,8 +281,6 @@ pub(crate) fn get_arrow<J: Jet>(
                         prod_b_c,
                         "Disconnect: Left target = B × C",
                     )?;
-                    unify(right_arrow.source.clone(), c, "Cannot fail")?;
-                    unify(right_arrow.target.clone(), d, "Cannot fail")?;
                 }
                 _ => unreachable!(),
             }

--- a/src/jet/type_name.rs
+++ b/src/jet/type_name.rs
@@ -39,7 +39,7 @@ use crate::core::types::{RcVar, Variable};
 /// | `h`  | 256-bit word |
 ///
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
-pub struct TypeName(pub(crate) &'static [u8]);
+pub struct TypeName(pub &'static [u8]);
 
 impl TypeName {
     // b'1' = 49

--- a/src/merkle/cmr.rs
+++ b/src/merkle/cmr.rs
@@ -25,7 +25,7 @@ use bitcoin_hashes::sha256::Midstate;
 
 /// Commitment Merkle root
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct Cmr(pub(crate) Midstate);
+pub struct Cmr(pub Midstate);
 
 impl_midstate_wrapper!(Cmr);
 


### PR DESCRIPTION
These are fixes from the [turing branch](https://github.com/uncomputable/rust-simplicity/commits/turing) that [simple-turing](https://github.com/uncomputable/simple-turing) builds upon.

Making some internals public makes it easier for other crates to use these types. Returning hashes of pruned branches or fail nodes makes debugging much easier. The type inference is fixed and the Miniscript policy compiler is slightly optimised.