### PR TITLE
Disable broken tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,26 @@ jobs:
           echo "No default features" && cargo test --no-default-features
           echo "All features" && cargo test --all-features
 
+  ignored:
+    name: Ignored Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v2
+      - name: Checkout Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - name: Running cargo test
+        run: |
+          cargo test -- --ignored
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/src/jet/elements/tests.rs
+++ b/src/jet/elements/tests.rs
@@ -29,6 +29,9 @@ fn sighash_all_cmr() {
     // TODO: check IMR
 }
 
+/*
+TODO: Add c_jet_ptr for used jets and re-enable tests
+
 #[test]
 #[ignore] // too expensive to run. Run with -- --ignored to run this
 fn exec_sighash_all() {
@@ -153,6 +156,7 @@ fn exec_sighash_all() {
     let mut mac = BitMachine::for_program(&program);
     mac.exec(&program, &env).unwrap();
 }
+*/
 
 #[test]
 fn test_ffi_env() {

--- a/src/test_progs/mod.rs
+++ b/src/test_progs/mod.rs
@@ -90,9 +90,13 @@ mod tests {
         exec_prog(&SCHNORR6);
     }
 
+    /*
+    TODO: Add c_jet_ptr for used jets and re-enable tests
+
     #[test]
     #[ignore] // too expensive to run. Run with -- --ignored and --release to run this
     fn schnorr0() {
         exec_prog(&SCHNORR0);
     }
+    */
 }


### PR DESCRIPTION
Some tests broke because of missing `c_jet_ptr`s. We didn't catch this because they were ignored.